### PR TITLE
Switch to "inline else" on some unions

### DIFF
--- a/src/pixel.zig
+++ b/src/pixel.zig
@@ -415,9 +415,7 @@ pub const Pixel = union(Format) {
     /// All pixel types with color channels are expected to be pre-multiplied.
     pub fn srcOver(dst: Pixel, src: Pixel) Pixel {
         return switch (dst) {
-            .rgb => |d| d.srcOver(src),
-            .rgba => |d| d.srcOver(src),
-            .alpha8 => |d| d.srcOver(src),
+            inline else => |d| d.srcOver(src),
         };
     }
 
@@ -427,9 +425,7 @@ pub const Pixel = union(Format) {
     /// All pixel types with color channels are expected to be pre-multiplied.
     pub fn dstIn(dst: Pixel, src: Pixel) Pixel {
         return switch (dst) {
-            .rgb => |d| d.dstIn(src),
-            .rgba => |d| d.dstIn(src),
-            .alpha8 => |d| d.dstIn(src),
+            inline else => |d| d.dstIn(src),
         };
     }
 };


### PR DESCRIPTION
This removes some boilerplate from tagged unions, see #7 for some more discussion.