### PR TITLE
path: move fill/stroke to context

### DIFF
--- a/spec/003_fill_triangle.zig
+++ b/spec/003_fill_triangle.zig
@@ -21,7 +21,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     const margin = 10;
@@ -30,7 +30,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     try path.lineTo(.{ .x = width / 2 - 1, .y = height - margin - 1 });
     try path.closePath();
 
-    try path.fill();
+    try context.fill(alloc, path);
 
     return sfc;
 }

--- a/spec/004_fill_square.zig
+++ b/spec/004_fill_square.zig
@@ -21,7 +21,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     const margin = 50;
@@ -31,7 +31,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     try path.lineTo(.{ .x = 0 + margin, .y = height - margin - 1 });
     try path.closePath();
 
-    try path.fill();
+    try context.fill(alloc, path);
 
     return sfc;
 }

--- a/spec/005_fill_trapezoid.zig
+++ b/spec/005_fill_trapezoid.zig
@@ -21,7 +21,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     const margin_top = 89;
@@ -33,7 +33,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     try path.lineTo(.{ .x = 0 + margin_bottom, .y = height - margin_y - 1 });
     try path.closePath();
 
-    try path.fill();
+    try context.fill(alloc, path);
 
     return sfc;
 }

--- a/spec/006_fill_star_even_odd.zig
+++ b/spec/006_fill_star_even_odd.zig
@@ -25,7 +25,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     const margin = 20;
@@ -40,7 +40,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     try path.lineTo(.{ .x = 0 + margin * x_scale, .y = height - margin - 1 }); // 4
     try path.closePath();
 
-    try path.fill();
+    try context.fill(alloc, path);
 
     return sfc;
 }

--- a/spec/007_fill_bezier.zig
+++ b/spec/007_fill_bezier.zig
@@ -21,7 +21,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     const p0: z2d.Point = .{ .x = 19, .y = 249 };
@@ -32,7 +32,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     try path.curveTo(p1, p2, p3);
     try path.closePath();
 
-    try path.fill();
+    try context.fill(alloc, path);
 
     return sfc;
 }

--- a/spec/008_stroke_triangle.zig
+++ b/spec/008_stroke_triangle.zig
@@ -21,7 +21,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     const margin = 10;
@@ -30,7 +30,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     try path.lineTo(.{ .x = width / 2 - 1, .y = height - margin - 1 });
     try path.closePath();
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     return sfc;
 }

--- a/spec/009_stroke_square.zig
+++ b/spec/009_stroke_square.zig
@@ -21,7 +21,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     const margin = 50;
@@ -31,7 +31,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     try path.lineTo(.{ .x = 0 + margin, .y = height - margin - 1 });
     try path.closePath();
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     return sfc;
 }

--- a/spec/010_stroke_trapezoid.zig
+++ b/spec/010_stroke_trapezoid.zig
@@ -21,7 +21,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     const margin_top = 89;
@@ -33,7 +33,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     try path.lineTo(.{ .x = 0 + margin_bottom, .y = height - margin_y - 1 });
     try path.closePath();
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     return sfc;
 }

--- a/spec/011_stroke_star.zig
+++ b/spec/011_stroke_star.zig
@@ -26,7 +26,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     const margin = 20;
@@ -41,7 +41,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     try path.lineTo(.{ .x = 0 + margin * x_scale, .y = height - margin - 1 }); // 4
     try path.closePath();
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     return sfc;
 }

--- a/spec/012_stroke_bezier.zig
+++ b/spec/012_stroke_bezier.zig
@@ -24,7 +24,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     var p0: z2d.Point = .{ .x = 19, .y = 149 };
@@ -33,7 +33,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     var p3: z2d.Point = .{ .x = 279, .y = 149 };
     try path.moveTo(p0);
     try path.curveTo(p1, p2, p3);
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     context.line_width = 6;
     path.reset();
@@ -43,7 +43,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     p3 = .{ .x = 279, .y = 199 };
     try path.moveTo(p0);
     try path.curveTo(p1, p2, p3);
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     context.line_width = 10;
     path.reset();
@@ -53,7 +53,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     p3 = .{ .x = 279, .y = 249 };
     try path.moveTo(p0);
     try path.curveTo(p1, p2, p3);
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     return sfc;
 }

--- a/spec/013_fill_combined.zig
+++ b/spec/013_fill_combined.zig
@@ -22,7 +22,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     // sub-canvas dimensions
@@ -81,7 +81,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     try path.curveTo(p1, p2, p3);
     try path.closePath();
 
-    try path.fill();
+    try context.fill(alloc, path);
 
     return sfc;
 }

--- a/spec/014_stroke_lines.zig
+++ b/spec/014_stroke_lines.zig
@@ -22,7 +22,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     // sub-canvas dimensions
@@ -125,7 +125,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .y = y_offset + sub_canvas_height / 2,
     });
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     return sfc;
 }

--- a/spec/015_stroke_miter.zig
+++ b/spec/015_stroke_miter.zig
@@ -22,7 +22,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     try path.moveTo(.{
@@ -261,7 +261,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .y = y_offset + 60,
     });
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     return sfc;
 }

--- a/spec/016_fill_star_non_zero.zig
+++ b/spec/016_fill_star_non_zero.zig
@@ -25,7 +25,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     const margin = 20;
@@ -40,7 +40,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     try path.lineTo(.{ .x = 0 + margin * x_scale, .y = height - margin - 1 }); // 4
     try path.closePath();
 
-    try path.fill();
+    try context.fill(alloc, path);
 
     return sfc;
 }

--- a/spec/017_stroke_star_round.zig
+++ b/spec/017_stroke_star_round.zig
@@ -23,7 +23,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     const margin = 20;
@@ -38,7 +38,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     try path.lineTo(.{ .x = 0 + margin * x_scale, .y = height - margin - 1 }); // 4
     try path.closePath();
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     return sfc;
 }

--- a/spec/018_stroke_square_spiral_round.zig
+++ b/spec/018_stroke_square_spiral_round.zig
@@ -23,7 +23,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     try path.moveTo(.{
@@ -262,7 +262,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .y = y_offset + 60,
     });
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     return sfc;
 }

--- a/spec/019_stroke_bevel_miterlimit.zig
+++ b/spec/019_stroke_bevel_miterlimit.zig
@@ -33,7 +33,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     // NOTE: This does not test the default miter limit as it's very high (11
     // degrees, and you can see how tight even 18 degrees is here). We probably
     // should test the default limit via unit testing.
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     // Line 1, ~130 degrees (dx = 70)
@@ -106,7 +106,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .y = 90,
     });
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     // First miter case, rendered with a miter limit of 4. Note that this is
     // the SVG default (see the MDN page quoted higher up).
@@ -184,7 +184,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .y = 190,
     });
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     // Second miter case, rendered with a miter limit of 1
     context.miter_limit = 1;
@@ -260,7 +260,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .y = 290,
     });
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     // Third miter case, rendered with a miter limit of 6
     context.miter_limit = 6;
@@ -336,7 +336,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .y = 390,
     });
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     // Fourth miter case, rendered with a miter limit of 10 (default)
     context.miter_limit = 10;
@@ -412,7 +412,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .y = 490,
     });
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     return sfc;
 }

--- a/spec/020_stroke_lines_round_caps.zig
+++ b/spec/020_stroke_lines_round_caps.zig
@@ -24,7 +24,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     // sub-canvas dimensions
@@ -220,14 +220,14 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .y = y_offset + margin,
     });
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     // We draw a hairline in the same path in red - this validates how the caps
     // and joins are aligned.
     context.pattern.opaque_pattern.pixel = .{ .rgb = .{ .r = 0xF3, .g = 0x00, .b = 0x00 } }; // Red
     context.line_width = 1;
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     return sfc;
 }

--- a/spec/021_stroke_lines_square_caps.zig
+++ b/spec/021_stroke_lines_square_caps.zig
@@ -23,7 +23,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     // sub-canvas dimensions
@@ -219,14 +219,14 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .y = y_offset + margin,
     });
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     // We draw a hairline in the same path in red - this validates how the caps
     // and joins are aligned.
     context.pattern.opaque_pattern.pixel = .{ .rgb = .{ .r = 0xF3, .g = 0x00, .b = 0x00 } }; // Red
     context.line_width = 1;
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     return sfc;
 }

--- a/spec/022_stroke_lines_butt_caps.zig
+++ b/spec/022_stroke_lines_butt_caps.zig
@@ -23,7 +23,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     // sub-canvas dimensions
@@ -219,14 +219,14 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .y = y_offset + margin,
     });
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     // We draw a hairline in the same path in red - this validates how the caps
     // and joins are aligned.
     context.pattern.opaque_pattern.pixel = .{ .rgb = .{ .r = 0xF3, .g = 0x00, .b = 0x00 } }; // Red
     context.line_width = 1;
 
-    try path.stroke();
+    try context.stroke(alloc, path);
 
     return sfc;
 }

--- a/spec/024_fill_triangle_direct_cross_format.zig
+++ b/spec/024_fill_triangle_direct_cross_format.zig
@@ -23,7 +23,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
         .anti_aliasing_mode = aa_mode,
     };
 
-    var path = z2d.PathOperation.init(alloc, &context);
+    var path = z2d.PathOperation.init(alloc);
     defer path.deinit();
 
     const margin = 10;
@@ -32,7 +32,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.AntiAliasMode) !z2d.Surface {
     try path.lineTo(.{ .x = width / 2 - 1, .y = height - margin - 1 });
     try path.closePath();
 
-    try path.fill();
+    try context.fill(alloc, path);
 
     return sfc;
 }

--- a/src/context.zig
+++ b/src/context.zig
@@ -1,13 +1,19 @@
-const testing = @import("std").testing;
+const mem = @import("std").mem;
 
 const surfacepkg = @import("surface.zig");
 const patternpkg = @import("pattern.zig");
 const pixelpkg = @import("pixel.zig");
 const options = @import("options.zig");
+const PathOperation = @import("path/path.zig").PathOperation;
+const fillerpkg = @import("path/filler.zig");
+const strokerpkg = @import("path/stroker.zig");
 
 /// The draw context, which connects patterns to surfaces, holds other state
 /// data, and is used to dispatch drawing operations.
 pub const DrawContext = struct {
+    /// The underlying surface.
+    surface: surfacepkg.Surface,
+
     /// The underlying pattern.
     ///
     /// The default pattern is RGBA opaque black.
@@ -16,9 +22,6 @@ pub const DrawContext = struct {
             .pixel = .{ .rgba = .{ .r = 0x00, .g = 0x00, .b = 0x00, .a = 0xFF } },
         },
     },
-
-    /// The underlying surface.
-    surface: surfacepkg.Surface,
 
     /// The current line width for drawing operations, in pixels. This value is
     /// taken at call time during stroke operations in a path, and has no
@@ -54,4 +57,48 @@ pub const DrawContext = struct {
     /// The current anti-aliasing mode. The default is the aptly-named
     /// "default" anti-aliasing mode.
     anti_aliasing_mode: options.AntiAliasMode = .default,
+
+    /// Runs a fill operation on the path(s) in the supplied set. All paths in
+    /// the set must be closed.
+    ///
+    /// This is a no-op if there are no nodes.
+    pub fn fill(self: *DrawContext, alloc: mem.Allocator, path: PathOperation) !void {
+        if (path.nodes.items.len == 0) return;
+        if (!path.closed()) return error.PathNotClosed;
+
+        try fillerpkg.fill(
+            alloc,
+            path.nodes,
+            self.surface,
+            self.pattern,
+            self.anti_aliasing_mode,
+            self.fill_rule,
+        );
+    }
+
+    /// Strokes a line for the path(s) in the supplied set.
+    ///
+    /// The behavior of open and closed paths are different for stroking. For
+    /// open paths (not explicitly closed with closePath), the start and the
+    /// end of the line are capped using the style set in line_cap_mode (e.g.,
+    /// butt, round, or square). For closed paths (ones that *are* explicitly
+    /// closed with closePath), the intersection joint of the start and end are
+    /// instead joined, along with all other joints along the way, with the
+    /// style set in line_join_mode (e.g., miter, round, or bevel).
+    ///
+    /// This is a no-op if there are no nodes.
+    pub fn stroke(self: *DrawContext, alloc: mem.Allocator, path: PathOperation) !void {
+        if (path.nodes.items.len == 0) return;
+        try strokerpkg.stroke(
+            alloc,
+            path.nodes,
+            self.surface,
+            self.pattern,
+            self.anti_aliasing_mode,
+            self.line_width,
+            self.line_join_mode,
+            self.miter_limit,
+            self.line_cap_mode,
+        );
+    }
 };

--- a/src/path/filler.zig
+++ b/src/path/filler.zig
@@ -15,7 +15,7 @@ const options = @import("../options.zig");
 /// Runs a fill operation on this current path and any subpaths.
 pub fn fill(
     alloc: mem.Allocator,
-    nodes: *std.ArrayList(nodepkg.PathNode),
+    nodes: std.ArrayList(nodepkg.PathNode),
     surface: surfacepkg.Surface,
     pattern: patternpkg.Pattern,
     anti_aliasing_mode: options.AntiAliasMode,
@@ -46,7 +46,7 @@ pub fn fill(
 /// use AA.
 fn paintDirect(
     alloc: mem.Allocator,
-    nodes: *std.ArrayList(nodepkg.PathNode),
+    nodes: std.ArrayList(nodepkg.PathNode),
     surface: surfacepkg.Surface,
     pattern: patternpkg.Pattern,
     fill_rule: options.FillRule,
@@ -89,7 +89,7 @@ fn paintDirect(
 /// implemented).
 fn paintComposite(
     alloc: mem.Allocator,
-    nodes: *std.ArrayList(nodepkg.PathNode),
+    nodes: std.ArrayList(nodepkg.PathNode),
     surface: surfacepkg.Surface,
     pattern: patternpkg.Pattern,
     fill_rule: options.FillRule,
@@ -189,7 +189,7 @@ fn paintComposite(
 /// list suitable for filling.
 ///
 /// The caller owns the polygon list and needs to call deinit on it.
-fn plot(alloc: mem.Allocator, nodes: *std.ArrayList(nodepkg.PathNode), scale: f64) !polypkg.PolygonList {
+fn plot(alloc: mem.Allocator, nodes: std.ArrayList(nodepkg.PathNode), scale: f64) !polypkg.PolygonList {
     var polygon_list = polypkg.PolygonList.init(alloc, scale);
     errdefer polygon_list.deinit();
 

--- a/src/path/stroke_transformer.zig
+++ b/src/path/stroke_transformer.zig
@@ -22,7 +22,7 @@ const default_tolerance: f64 = 0.1;
 /// called on it.
 pub fn transform(
     alloc: mem.Allocator,
-    nodes: *std.ArrayList(nodepkg.PathNode),
+    nodes: std.ArrayList(nodepkg.PathNode),
     thickness: f64,
     join_mode: options.JoinMode,
     miter_limit: f64,
@@ -52,7 +52,7 @@ pub fn transform(
 const StrokeNodeIterator = struct {
     alloc: mem.Allocator,
     thickness: f64,
-    items: *const std.ArrayList(nodepkg.PathNode),
+    items: std.ArrayList(nodepkg.PathNode),
     index: usize = 0,
     join_mode: options.JoinMode,
     miter_limit: f64,

--- a/src/path/stroker.zig
+++ b/src/path/stroker.zig
@@ -14,7 +14,7 @@ const options = @import("../options.zig");
 /// then filled.
 pub fn stroke(
     alloc: mem.Allocator,
-    nodes: *std.ArrayList(nodepkg.PathNode),
+    nodes: std.ArrayList(nodepkg.PathNode),
     surface: surfacepkg.Surface,
     pattern: patternpkg.Pattern,
     anti_aliasing_mode: options.AntiAliasMode,
@@ -45,5 +45,5 @@ pub fn stroke(
         if (thickness >= 2) cap_mode else .butt,
     );
     defer stroke_nodes.deinit();
-    try fillerpkg.fill(alloc, &stroke_nodes, surface, pattern, anti_aliasing_mode, .non_zero);
+    try fillerpkg.fill(alloc, stroke_nodes, surface, pattern, anti_aliasing_mode, .non_zero);
 }


### PR DESCRIPTION
This moves the fill and stroke operations to `DrawContext`.

The rationale: most of the parameters these operations need reside in `DrawContext`, and the fill/stroke operations needed to reach back into it for these details. Having the operations themselves live there should reduce the complexity in this regard.

In addition to taking the path as parameters here, we also take the allocator. This should make it pretty clear what is required for the operations.

We've also made the array lists in the filler/stroker bits "pass-by-value"; quotes are used here because `ArrayList` actually stores a pointer to the underlying slice, so nothing is actually copied other than capacity and the allocator (which in turn is also just pointers). Hence, the items in the `ArrayList` itself are not copied. This also makes all of these parameters immutable, meaning we can't use any of the methods on the `ArrayList`, which should communicate that the passed in nodes are read-only.