### PR TITLE
internal: use single-instance pen

### DIFF
--- a/src/internal/Pen.zig
+++ b/src/internal/Pen.zig
@@ -1,5 +1,5 @@
-/// A Pen represents a circular area designed for specific stroking operations,
-/// such as round joins and caps.
+//! A Pen represents a circular area designed for specific stroking operations,
+//! such as round joins and caps.
 const Pen = @This();
 
 const std = @import("std");
@@ -122,7 +122,7 @@ pub fn deinit(self: *Pen) void {
 ///
 /// The caller owns the ArrayList and must call deinit on it.
 pub fn verticesForJoin(
-    self: *Pen,
+    self: *const Pen,
     from_slope: Slope,
     to_slope: Slope,
     clockwise: bool,


### PR DESCRIPTION
Fixes #8.

Note that there's going to be a lot more cleanup here, but this specifically ensures that we don't re-initialize the pen on every join/cap.

![image](https://github.com/vancluever/z2d/assets/10704423/32870791-970c-4e87-84f6-8c13adde7b39)