### PR TITLE
Surface: move to unmanaged and infallible design

### DIFF
--- a/spec/001_smile_rgb.zig
+++ b/spec/001_smile_rgb.zig
@@ -31,13 +31,7 @@ pub fn render(alloc: mem.Allocator) !z2d.Surface {
         }
 
         const px: z2d.Pixel = if (c == '0') foregrounds[0] else backgrounds[0];
-        sfc.putPixel(x, y, px) catch |err| {
-            debug.print(
-                "error at image 1, pixel (x, y): ({}, {}), ({}, {})\n",
-                .{ x, y, h, w },
-            );
-            return err;
-        };
+        sfc.putPixel(x, y, px);
         x += 1;
     }
 
@@ -53,13 +47,7 @@ pub fn render(alloc: mem.Allocator) !z2d.Surface {
         }
 
         const px: z2d.Pixel = if (c == '0') foregrounds[1] else backgrounds[1];
-        sfc.putPixel(x, y, px) catch |err| {
-            debug.print(
-                "error at image 2, pixel (x, y), (h, w): ({}, {}), ({}, {})\n",
-                .{ x, y, h, w },
-            );
-            return err;
-        };
+        sfc.putPixel(x, y, px);
         x += 1;
     }
 
@@ -75,13 +63,7 @@ pub fn render(alloc: mem.Allocator) !z2d.Surface {
         }
 
         const px: z2d.Pixel = if (c == '0') foregrounds[2] else backgrounds[2];
-        sfc.putPixel(x, y, px) catch |err| {
-            debug.print(
-                "error at image 3, pixel (x, y), (h, w): ({}, {}), ({}, {})\n",
-                .{ x, y, h, w },
-            );
-            return err;
-        };
+        sfc.putPixel(x, y, px);
         x += 1;
     }
 

--- a/spec/002_smile_rgba.zig
+++ b/spec/002_smile_rgba.zig
@@ -34,13 +34,7 @@ pub fn render(alloc: mem.Allocator) !z2d.Surface {
         }
 
         const px: z2d.Pixel = if (c == '0') foregrounds[0] else backgrounds[0];
-        sfc.putPixel(x, y, px) catch |err| {
-            debug.print(
-                "error at image 1, pixel (x, y): ({}, {}), ({}, {})\n",
-                .{ x, y, h, w },
-            );
-            return err;
-        };
+        sfc.putPixel(x, y, px);
         x += 1;
     }
 
@@ -56,13 +50,7 @@ pub fn render(alloc: mem.Allocator) !z2d.Surface {
         }
 
         const px: z2d.Pixel = if (c == '0') foregrounds[1] else backgrounds[1];
-        sfc.putPixel(x, y, px) catch |err| {
-            debug.print(
-                "error at image 2, pixel (x, y), (h, w): ({}, {}), ({}, {})\n",
-                .{ x, y, h, w },
-            );
-            return err;
-        };
+        sfc.putPixel(x, y, px);
         x += 1;
     }
 
@@ -78,13 +66,7 @@ pub fn render(alloc: mem.Allocator) !z2d.Surface {
         }
 
         const px: z2d.Pixel = if (c == '0') foregrounds[2] else backgrounds[2];
-        sfc.putPixel(x, y, px) catch |err| {
-            debug.print(
-                "error at image 3, pixel (x, y), (h, w): ({}, {}), ({}, {})\n",
-                .{ x, y, h, w },
-            );
-            return err;
-        };
+        sfc.putPixel(x, y, px);
         x += 1;
     }
 

--- a/spec/023_smile_alpha_mask.zig
+++ b/spec/023_smile_alpha_mask.zig
@@ -28,7 +28,7 @@ pub fn render(alloc: mem.Allocator) !z2d.Surface {
         image.width,
         image.height,
     );
-    defer mask_sfc.deinit();
+    defer mask_sfc.deinit(alloc);
 
     var x: i32 = 0;
     var y: i32 = 0;
@@ -40,13 +40,7 @@ pub fn render(alloc: mem.Allocator) !z2d.Surface {
         }
 
         const px: z2d.Pixel = if (c == '0') .{ .alpha8 = .{ .a = 255 } } else .{ .alpha8 = .{ .a = 0 } };
-        mask_sfc.putPixel(x, y, px) catch |err| {
-            debug.print(
-                "error at mask image, pixel (x, y): ({}, {}), ({}, {})\n",
-                .{ x, y, image.width, image.height },
-            );
-            return err;
-        };
+        mask_sfc.putPixel(x, y, px);
         x += 1;
     }
 
@@ -63,41 +57,41 @@ pub fn render(alloc: mem.Allocator) !z2d.Surface {
     // you are probably better off just writing directly.
 
     // Create a working surface and paint it with the background color
-    const background_sfc = try z2d.Surface.initPixel(backgrounds[0], alloc, image.width, image.height);
-    defer background_sfc.deinit();
+    var background_sfc = try z2d.Surface.initPixel(backgrounds[0], alloc, image.width, image.height);
+    defer background_sfc.deinit(alloc);
     // Make our foreground surface
-    const foreground_sfc = try z2d.Surface.initPixel(foregrounds[0], alloc, image.width, image.height);
-    defer foreground_sfc.deinit();
+    var foreground_sfc = try z2d.Surface.initPixel(foregrounds[0], alloc, image.width, image.height);
+    defer foreground_sfc.deinit(alloc);
     // Apply mask to foreground
-    try foreground_sfc.dstIn(mask_sfc, 0, 0);
+    foreground_sfc.dstIn(&mask_sfc, 0, 0);
     // Apply foreground to background
-    try background_sfc.srcOver(foreground_sfc, 0, 0);
+    background_sfc.srcOver(&foreground_sfc, 0, 0);
     // Composite our working surface at our first offset co-ordinates
-    try result_sfc.srcOver(background_sfc, 12, 13);
+    result_sfc.srcOver(&background_sfc, 12, 13);
 
     // 2nd smile
     //
     // Re-paint with the second background color.
-    try background_sfc.paintPixel(backgrounds[1]);
+    background_sfc.paintPixel(backgrounds[1]);
     // Re-paint foreground and apply mask
-    try foreground_sfc.paintPixel(foregrounds[1]);
-    try foreground_sfc.dstIn(mask_sfc, 0, 0);
+    foreground_sfc.paintPixel(foregrounds[1]);
+    foreground_sfc.dstIn(&mask_sfc, 0, 0);
     // Apply foreground to background
-    try background_sfc.srcOver(foreground_sfc, 0, 0);
+    background_sfc.srcOver(&foreground_sfc, 0, 0);
     // Composite our working surface at our second offset co-ordinates
-    try result_sfc.srcOver(background_sfc, w / 2 - 7, 13);
+    result_sfc.srcOver(&background_sfc, w / 2 - 7, 13);
 
     // 3rd smile
     //
     // Re-paint with the third background color.
-    try background_sfc.paintPixel(backgrounds[2]);
+    background_sfc.paintPixel(backgrounds[2]);
     // Re-paint foreground and apply mask
-    try foreground_sfc.paintPixel(foregrounds[2]);
-    try foreground_sfc.dstIn(mask_sfc, 0, 0);
+    foreground_sfc.paintPixel(foregrounds[2]);
+    foreground_sfc.dstIn(&mask_sfc, 0, 0);
     // Apply foreground to background
-    try background_sfc.srcOver(foreground_sfc, 0, 0);
+    background_sfc.srcOver(&foreground_sfc, 0, 0);
     // Composite our working surface at our second offset co-ordinates
-    try result_sfc.srcOver(background_sfc, w / 4 + 2, h / 2 - 7);
+    result_sfc.srcOver(&background_sfc, w / 4 + 2, h / 2 - 7);
 
     // done!
 

--- a/spec/main.zig
+++ b/spec/main.zig
@@ -358,7 +358,7 @@ fn compositorTestRun(alloc: mem.Allocator, subject: anytype) !void {
     defer alloc.free(filename);
 
     var surface = try subject.render(alloc);
-    defer surface.deinit();
+    defer surface.deinit(alloc);
 
     var exported_file = try testExportPNG(alloc, surface, filename);
     defer exported_file.cleanup();
@@ -381,9 +381,9 @@ fn pathTestRun(alloc: mem.Allocator, subject: anytype) !void {
     defer alloc.free(filename_smooth);
 
     var surface_pixelated = try subject.render(alloc, .none);
-    defer surface_pixelated.deinit();
+    defer surface_pixelated.deinit(alloc);
     var surface_smooth = try subject.render(alloc, .default);
-    defer surface_smooth.deinit();
+    defer surface_smooth.deinit(alloc);
 
     var exported_file_pixelated = try testExportPNG(alloc, surface_pixelated, filename_pixelated);
     defer exported_file_pixelated.cleanup();

--- a/src/export_png.zig
+++ b/src/export_png.zig
@@ -134,7 +134,7 @@ fn writePNGIDATStream(
 
         for (0..@intCast(sfc.getWidth())) |x| {
             nbytes += written: {
-                switch (try sfc.getPixel(@intCast(x), @intCast(y))) {
+                switch (sfc.getPixel(@intCast(x), @intCast(y)) orelse unreachable) {
                     // PNG writes out numbers big-endian, but *only numbers larger
                     // than a byte*. This means we need to handle each pixel format
                     // slightly differently with how we swap around bytes, etc.


### PR DESCRIPTION
This moves `Surface` and `ImageSurface` to an unmanaged, infallible design:

* Allocators are no longer stored in the surface.
* Anything that needs an allocator (e.g., `init`, `deinit`, and `downsample`) requires the same allocator to be used across the lifetime of the surface, as you would expect with unmanaged patterns within Zig.
* The only function that returns an error now is `init`. Every other function has a well-defined failure mode. Particularly, `getPixel` will return null on out-of-bounds requests, and `setPixel` will no-op. Additionally every pixel is valid on a surface for `setPixel` and `paintPixel`, using `copySrc` now instead of `fromPixel` (essentially making mismatched pixel types a cast).

Additionally, `ImageSurface` has gotten an `initBuffer` initializer. Using this function, the only sanity checking that's done is that you're using non-negative values for width and height; negative values cause a panic instead of an error. Otherwise, you are expected to have supplied the appropriately sized buffer for the appropriate type. There is a counterpart `downsampleBuffer` to use when you use this bring-your-own-buffer approach, so you don't have to supply an allocator to anything else (as if you did, it would be an illegal operation).

Note that due to the current state of the language and `ptrCast`-ing between slices of different alignments, `initBuffer` is currently not exposed in the union interface. As such, if you want to use `initBuffer`, you have to call the type function directly and then use `asSurfaceInterface`.