### PR TITLE
Context: new managed interface

### DIFF
--- a/spec/003_fill_triangle.zig
+++ b/spec/003_fill_triangle.zig
@@ -11,28 +11,19 @@ pub const filename = "003_fill_triangle";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
-
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
     const margin = 10;
-    try path.moveTo(alloc, 0 + margin, 0 + margin);
-    try path.lineTo(alloc, width - margin - 1, 0 + margin);
-    try path.lineTo(alloc, width / 2 - 1, height - margin - 1);
-    try path.close(alloc);
+    try context.moveTo(0 + margin, 0 + margin);
+    try context.lineTo(width - margin - 1, 0 + margin);
+    try context.lineTo(width / 2 - 1, height - margin - 1);
+    try context.close();
 
-    try context.fill(alloc, path);
+    try context.fill();
 
     return sfc;
 }

--- a/spec/004_fill_square.zig
+++ b/spec/004_fill_square.zig
@@ -11,29 +11,20 @@ pub const filename = "004_fill_square";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
-
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
     const margin = 50;
-    try path.moveTo(alloc, 0 + margin, 0 + margin);
-    try path.lineTo(alloc, width - margin - 1, 0 + margin);
-    try path.lineTo(alloc, width - margin - 1, height - margin - 1);
-    try path.lineTo(alloc, 0 + margin, height - margin - 1);
-    try path.close(alloc);
+    try context.moveTo(0 + margin, 0 + margin);
+    try context.lineTo(width - margin - 1, 0 + margin);
+    try context.lineTo(width - margin - 1, height - margin - 1);
+    try context.lineTo(0 + margin, height - margin - 1);
+    try context.close();
 
-    try context.fill(alloc, path);
+    try context.fill();
 
     return sfc;
 }

--- a/spec/005_fill_trapezoid.zig
+++ b/spec/005_fill_trapezoid.zig
@@ -11,31 +11,23 @@ pub const filename = "005_fill_trapezoid";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
     const margin_top = 89;
     const margin_bottom = 50;
     const margin_y = 100;
-    try path.moveTo(alloc, 0 + margin_top, 0 + margin_y);
-    try path.lineTo(alloc, width - margin_top - 1, 0 + margin_y);
-    try path.lineTo(alloc, width - margin_bottom - 1, height - margin_y - 1);
-    try path.lineTo(alloc, 0 + margin_bottom, height - margin_y - 1);
-    try path.close(alloc);
+    try context.moveTo(0 + margin_top, 0 + margin_y);
+    try context.lineTo(width - margin_top - 1, 0 + margin_y);
+    try context.lineTo(width - margin_bottom - 1, height - margin_y - 1);
+    try context.lineTo(0 + margin_bottom, height - margin_y - 1);
+    try context.close();
 
-    try context.fill(alloc, path);
+    try context.fill();
 
     return sfc;
 }

--- a/spec/006_fill_star_even_odd.zig
+++ b/spec/006_fill_star_even_odd.zig
@@ -14,35 +14,27 @@ pub const filename = "006_fill_star_even_odd";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .fill_rule = .even_odd,
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setFillRule(.even_odd);
 
     const margin = 20;
     const x_scale = 3;
     const y_scale = 5;
     // With all 5 points numbered 1-5 clockwise, we draw odds first (1, 3, 5),
     // then evens (4, 2), with the close connecting 4 and 1.
-    try path.moveTo(alloc, width / 2, 0 + margin); // 1
-    try path.lineTo(alloc, width - margin * x_scale - 1, height - margin - 1); // 3
-    try path.lineTo(alloc, 0 + margin, 0 + margin * y_scale); // 5
-    try path.lineTo(alloc, width - margin - 1, 0 + margin * y_scale); // 2
-    try path.lineTo(alloc, 0 + margin * x_scale, height - margin - 1); // 4
-    try path.close(alloc);
+    try context.moveTo(width / 2, 0 + margin); // 1
+    try context.lineTo(width - margin * x_scale - 1, height - margin - 1); // 3
+    try context.lineTo(0 + margin, 0 + margin * y_scale); // 5
+    try context.lineTo(width - margin - 1, 0 + margin * y_scale); // 2
+    try context.lineTo(0 + margin * x_scale, height - margin - 1); // 4
+    try context.close();
 
-    try context.fill(alloc, path);
+    try context.fill();
 
     return sfc;
 }

--- a/spec/007_fill_bezier.zig
+++ b/spec/007_fill_bezier.zig
@@ -11,26 +11,18 @@ pub const filename = "007_fill_bezier";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    try context.moveTo(19, 249);
+    try context.curveTo(89, 49, 209, 49, 279, 249);
+    try context.close();
 
-    try path.moveTo(alloc, 19, 249);
-    try path.curveTo(alloc, 89, 49, 209, 49, 279, 249);
-    try path.close(alloc);
-
-    try context.fill(alloc, path);
+    try context.fill();
 
     return sfc;
 }

--- a/spec/008_stroke_triangle.zig
+++ b/spec/008_stroke_triangle.zig
@@ -11,28 +11,20 @@ pub const filename = "008_stroke_triangle";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
     const margin = 10;
-    try path.moveTo(alloc, 0 + margin, 0 + margin);
-    try path.lineTo(alloc, width - margin - 1, 0 + margin);
-    try path.lineTo(alloc, width / 2 - 1, height - margin - 1);
-    try path.close(alloc);
+    try context.moveTo(0 + margin, 0 + margin);
+    try context.lineTo(width - margin - 1, 0 + margin);
+    try context.lineTo(width / 2 - 1, height - margin - 1);
+    try context.close();
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/009_stroke_square.zig
+++ b/spec/009_stroke_square.zig
@@ -11,29 +11,21 @@ pub const filename = "009_stroke_square";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
     const margin = 50;
-    try path.moveTo(alloc, 0 + margin, 0 + margin);
-    try path.lineTo(alloc, width - margin - 1, 0 + margin);
-    try path.lineTo(alloc, width - margin - 1, height - margin - 1);
-    try path.lineTo(alloc, 0 + margin, height - margin - 1);
-    try path.close(alloc);
+    try context.moveTo(0 + margin, 0 + margin);
+    try context.lineTo(width - margin - 1, 0 + margin);
+    try context.lineTo(width - margin - 1, height - margin - 1);
+    try context.lineTo(0 + margin, height - margin - 1);
+    try context.close();
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/010_stroke_trapezoid.zig
+++ b/spec/010_stroke_trapezoid.zig
@@ -11,31 +11,23 @@ pub const filename = "010_stroke_trapezoid";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
     const margin_top = 89;
     const margin_bottom = 50;
     const margin_y = 100;
-    try path.moveTo(alloc, 0 + margin_top, 0 + margin_y);
-    try path.lineTo(alloc, width - margin_top - 1, 0 + margin_y);
-    try path.lineTo(alloc, width - margin_bottom - 1, height - margin_y - 1);
-    try path.lineTo(alloc, 0 + margin_bottom, height - margin_y - 1);
-    try path.close(alloc);
+    try context.moveTo(0 + margin_top, 0 + margin_y);
+    try context.lineTo(width - margin_top - 1, 0 + margin_y);
+    try context.lineTo(width - margin_bottom - 1, height - margin_y - 1);
+    try context.lineTo(0 + margin_bottom, height - margin_y - 1);
+    try context.close();
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/011_stroke_star.zig
+++ b/spec/011_stroke_star.zig
@@ -15,35 +15,27 @@ pub const filename = "011_stroke_star";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .line_width = 6,
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(6);
 
     const margin = 20;
     const x_scale = 3;
     const y_scale = 5;
     // With all 5 points numbered 1-5 clockwise, we draw odds first (1, 3, 5),
     // then evens (4, 2), with the close connecting 4 and 1.
-    try path.moveTo(alloc, width / 2, 0 + margin); // 1
-    try path.lineTo(alloc, width - margin * x_scale - 1, height - margin - 1); // 3
-    try path.lineTo(alloc, 0 + margin, 0 + margin * y_scale); // 5
-    try path.lineTo(alloc, width - margin - 1, 0 + margin * y_scale); // 2
-    try path.lineTo(alloc, 0 + margin * x_scale, height - margin - 1); // 4
-    try path.close(alloc);
+    try context.moveTo(width / 2, 0 + margin); // 1
+    try context.lineTo(width - margin * x_scale - 1, height - margin - 1); // 3
+    try context.lineTo(0 + margin, 0 + margin * y_scale); // 5
+    try context.lineTo(width - margin - 1, 0 + margin * y_scale); // 2
+    try context.lineTo(0 + margin * x_scale, height - margin - 1); // 4
+    try context.close();
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/012_stroke_bezier.zig
+++ b/spec/012_stroke_bezier.zig
@@ -14,36 +14,28 @@ pub const filename = "012_stroke_bezier";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    try context.moveTo(19, 149);
+    try context.curveTo(89, 0, 209, 0, 279, 149);
+    try context.stroke();
 
-    try path.moveTo(alloc, 19, 149);
-    try path.curveTo(alloc, 89, 0, 209, 0, 279, 149);
-    try context.stroke(alloc, path);
+    context.setLineWidth(6);
+    context.resetPath();
+    try context.moveTo(19, 199);
+    try context.curveTo(89, 24, 209, 24, 279, 199);
+    try context.stroke();
 
-    context.line_width = 6;
-    path.reset();
-    try path.moveTo(alloc, 19, 199);
-    try path.curveTo(alloc, 89, 24, 209, 24, 279, 199);
-    try context.stroke(alloc, path);
-
-    context.line_width = 10;
-    path.reset();
-    try path.moveTo(alloc, 19, 249);
-    try path.curveTo(alloc, 89, 49, 209, 49, 279, 249);
-    try context.stroke(alloc, path);
+    context.setLineWidth(10);
+    context.resetPath();
+    try context.moveTo(19, 249);
+    try context.curveTo(89, 49, 209, 49, 279, 249);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/013_fill_combined.zig
+++ b/spec/013_fill_combined.zig
@@ -12,20 +12,12 @@ pub const filename = "013_fill_combined";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 600;
     const height = 400;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
     // sub-canvas dimensions
     const sub_canvas_width = width / 3;
@@ -33,30 +25,30 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
 
     // Triangle
     comptime var margin = 10;
-    try path.moveTo(alloc, 0 + margin, 0 + margin);
-    try path.lineTo(alloc, sub_canvas_width - margin - 1, 0 + margin);
-    try path.lineTo(alloc, sub_canvas_width / 2 - 1, sub_canvas_height - margin - 1);
-    try path.close(alloc);
+    try context.moveTo(0 + margin, 0 + margin);
+    try context.lineTo(sub_canvas_width - margin - 1, 0 + margin);
+    try context.lineTo(sub_canvas_width / 2 - 1, sub_canvas_height - margin - 1);
+    try context.close();
 
     // Square
     margin = 50;
     comptime var x_offset = sub_canvas_width;
-    try path.moveTo(alloc, x_offset + margin, 0 + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, 0 + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + margin, sub_canvas_height - margin - 1);
-    try path.close(alloc);
+    try context.moveTo(x_offset + margin, 0 + margin);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, 0 + margin);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + margin, sub_canvas_height - margin - 1);
+    try context.close();
 
     // Trapezoid
     const trapezoid_margin_top = 59;
     const trapezoid_margin_bottom = 33;
     const trapezoid_margin_y = 66;
     x_offset = sub_canvas_width * 2;
-    try path.moveTo(alloc, x_offset + trapezoid_margin_top, 0 + trapezoid_margin_y);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - trapezoid_margin_top - 1, 0 + trapezoid_margin_y);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - trapezoid_margin_bottom - 1, sub_canvas_height - trapezoid_margin_y - 1);
-    try path.lineTo(alloc, x_offset + trapezoid_margin_bottom, sub_canvas_height - trapezoid_margin_y - 1);
-    try path.close(alloc);
+    try context.moveTo(x_offset + trapezoid_margin_top, 0 + trapezoid_margin_y);
+    try context.lineTo(x_offset + sub_canvas_width - trapezoid_margin_top - 1, 0 + trapezoid_margin_y);
+    try context.lineTo(x_offset + sub_canvas_width - trapezoid_margin_bottom - 1, sub_canvas_height - trapezoid_margin_y - 1);
+    try context.lineTo(x_offset + trapezoid_margin_bottom, sub_canvas_height - trapezoid_margin_y - 1);
+    try context.close();
 
     // Star
     margin = 13;
@@ -66,20 +58,20 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     const y_offset = sub_canvas_height;
     // With all 5 points numbered 1-5 clockwise, we draw odds first (1, 3, 5),
     // then evens (4, 2), with the close connecting 4 and 1.
-    try path.moveTo(alloc, x_offset + sub_canvas_width / 2, y_offset + margin); // 1
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin * x_scale - 1, y_offset + sub_canvas_height - margin - 1); // 3
-    try path.lineTo(alloc, x_offset + margin, y_offset + margin * y_scale); // 5
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin * y_scale); // 2
-    try path.lineTo(alloc, x_offset + margin * x_scale, y_offset + sub_canvas_height - margin - 1); // 4
-    try path.close(alloc);
+    try context.moveTo(x_offset + sub_canvas_width / 2, y_offset + margin); // 1
+    try context.lineTo(x_offset + sub_canvas_width - margin * x_scale - 1, y_offset + sub_canvas_height - margin - 1); // 3
+    try context.lineTo(x_offset + margin, y_offset + margin * y_scale); // 5
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin * y_scale); // 2
+    try context.lineTo(x_offset + margin * x_scale, y_offset + sub_canvas_height - margin - 1); // 4
+    try context.close();
 
     // Bezier
     x_offset += sub_canvas_width;
-    try path.moveTo(alloc, x_offset + 12, y_offset + 166);
-    try path.curveTo(alloc, x_offset + 59, y_offset + 32, x_offset + 139, y_offset + 32, x_offset + 186, y_offset + 166);
-    try path.close(alloc);
+    try context.moveTo(x_offset + 12, y_offset + 166);
+    try context.curveTo(x_offset + 59, y_offset + 32, x_offset + 139, y_offset + 32, x_offset + 186, y_offset + 166);
+    try context.close();
 
-    try context.fill(alloc, path);
+    try context.fill();
 
     return sfc;
 }

--- a/spec/014_stroke_lines.zig
+++ b/spec/014_stroke_lines.zig
@@ -12,20 +12,12 @@ pub const filename = "014_stroke_lines";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 800;
     const height = 400;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
     // sub-canvas dimensions
     const sub_canvas_width = width / 4;
@@ -35,51 +27,51 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     const margin = 10;
     comptime var x_offset = 0;
     comptime var y_offset = 0;
-    try path.moveTo(alloc, x_offset + margin, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + margin, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
 
     // Up and to the right
     x_offset = sub_canvas_width;
-    try path.moveTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.moveTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
 
     // Down and to the left
     x_offset = 0;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
 
     // Up and to the left
     x_offset = sub_canvas_width;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + margin, y_offset + margin);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + margin, y_offset + margin);
 
     // Horizontal (left -> right)
     x_offset = sub_canvas_width * 2;
     y_offset = 0;
-    try path.moveTo(alloc, x_offset + margin, y_offset + sub_canvas_height / 2);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
+    try context.moveTo(x_offset + margin, y_offset + sub_canvas_height / 2);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
 
     // Vertical (up -> down)
     x_offset = sub_canvas_width * 2;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width / 2, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + sub_canvas_width / 2, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
 
     // Vertical (down -> up)
     x_offset = sub_canvas_width * 3;
     y_offset = 0;
-    try path.moveTo(alloc, x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2, y_offset + margin);
+    try context.moveTo(x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width / 2, y_offset + margin);
 
     // Horizontal (right -> left)
     x_offset = sub_canvas_width * 3;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height / 2);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height / 2);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/015_stroke_miter.zig
+++ b/spec/015_stroke_miter.zig
@@ -11,91 +11,83 @@ pub const filename = "015_stroke_miter";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 240;
     const height = 260;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .line_width = 6,
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(6);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
-
-    try path.moveTo(alloc, 10, 10);
-    try path.lineTo(alloc, 100, 20);
-    try path.lineTo(alloc, 110, 120);
-    try path.lineTo(alloc, 10, 110);
-    try path.lineTo(alloc, 20, 30);
-    try path.lineTo(alloc, 90, 40);
-    try path.lineTo(alloc, 95, 100);
-    try path.lineTo(alloc, 30, 95);
-    try path.lineTo(alloc, 30, 50);
-    try path.lineTo(alloc, 80, 50);
-    try path.lineTo(alloc, 75, 85);
-    try path.lineTo(alloc, 45, 80);
-    try path.lineTo(alloc, 50, 60);
-    try path.lineTo(alloc, 65, 70);
+    try context.moveTo(10, 10);
+    try context.lineTo(100, 20);
+    try context.lineTo(110, 120);
+    try context.lineTo(10, 110);
+    try context.lineTo(20, 30);
+    try context.lineTo(90, 40);
+    try context.lineTo(95, 100);
+    try context.lineTo(30, 95);
+    try context.lineTo(30, 50);
+    try context.lineTo(80, 50);
+    try context.lineTo(75, 85);
+    try context.lineTo(45, 80);
+    try context.lineTo(50, 60);
+    try context.lineTo(65, 70);
 
     ////////////////////
     const x_offset = 120;
 
-    try path.moveTo(alloc, x_offset + 110, 10);
-    try path.lineTo(alloc, x_offset + 20, 20);
-    try path.lineTo(alloc, x_offset + 10, 120);
-    try path.lineTo(alloc, x_offset + 110, 110);
-    try path.lineTo(alloc, x_offset + 100, 30);
-    try path.lineTo(alloc, x_offset + 30, 40);
-    try path.lineTo(alloc, x_offset + 25, 100);
-    try path.lineTo(alloc, x_offset + 90, 95);
-    try path.lineTo(alloc, x_offset + 90, 50);
-    try path.lineTo(alloc, x_offset + 40, 50);
-    try path.lineTo(alloc, x_offset + 45, 85);
-    try path.lineTo(alloc, x_offset + 75, 80);
-    try path.lineTo(alloc, x_offset + 70, 60);
-    try path.lineTo(alloc, x_offset + 55, 70);
+    try context.moveTo(x_offset + 110, 10);
+    try context.lineTo(x_offset + 20, 20);
+    try context.lineTo(x_offset + 10, 120);
+    try context.lineTo(x_offset + 110, 110);
+    try context.lineTo(x_offset + 100, 30);
+    try context.lineTo(x_offset + 30, 40);
+    try context.lineTo(x_offset + 25, 100);
+    try context.lineTo(x_offset + 90, 95);
+    try context.lineTo(x_offset + 90, 50);
+    try context.lineTo(x_offset + 40, 50);
+    try context.lineTo(x_offset + 45, 85);
+    try context.lineTo(x_offset + 75, 80);
+    try context.lineTo(x_offset + 70, 60);
+    try context.lineTo(x_offset + 55, 70);
 
     ////////////////////
     const y_offset = 130;
 
-    try path.moveTo(alloc, 10, y_offset + 120);
-    try path.lineTo(alloc, 100, y_offset + 110);
-    try path.lineTo(alloc, 110, y_offset + 10);
-    try path.lineTo(alloc, 10, y_offset + 20);
-    try path.lineTo(alloc, 20, y_offset + 100);
-    try path.lineTo(alloc, 90, y_offset + 90);
-    try path.lineTo(alloc, 95, y_offset + 30);
-    try path.lineTo(alloc, 30, y_offset + 35);
-    try path.lineTo(alloc, 30, y_offset + 80);
-    try path.lineTo(alloc, 80, y_offset + 80);
-    try path.lineTo(alloc, 75, y_offset + 45);
-    try path.lineTo(alloc, 45, y_offset + 50);
-    try path.lineTo(alloc, 50, y_offset + 70);
-    try path.lineTo(alloc, 65, y_offset + 60);
+    try context.moveTo(10, y_offset + 120);
+    try context.lineTo(100, y_offset + 110);
+    try context.lineTo(110, y_offset + 10);
+    try context.lineTo(10, y_offset + 20);
+    try context.lineTo(20, y_offset + 100);
+    try context.lineTo(90, y_offset + 90);
+    try context.lineTo(95, y_offset + 30);
+    try context.lineTo(30, y_offset + 35);
+    try context.lineTo(30, y_offset + 80);
+    try context.lineTo(80, y_offset + 80);
+    try context.lineTo(75, y_offset + 45);
+    try context.lineTo(45, y_offset + 50);
+    try context.lineTo(50, y_offset + 70);
+    try context.lineTo(65, y_offset + 60);
 
     ////////////////////
 
-    try path.moveTo(alloc, x_offset + 110, y_offset + 120);
-    try path.lineTo(alloc, x_offset + 20, y_offset + 110);
-    try path.lineTo(alloc, x_offset + 10, y_offset + 10);
-    try path.lineTo(alloc, x_offset + 110, y_offset + 20);
-    try path.lineTo(alloc, x_offset + 100, y_offset + 100);
-    try path.lineTo(alloc, x_offset + 30, y_offset + 90);
-    try path.lineTo(alloc, x_offset + 25, y_offset + 30);
-    try path.lineTo(alloc, x_offset + 90, y_offset + 35);
-    try path.lineTo(alloc, x_offset + 90, y_offset + 80);
-    try path.lineTo(alloc, x_offset + 40, y_offset + 80);
-    try path.lineTo(alloc, x_offset + 45, y_offset + 45);
-    try path.lineTo(alloc, x_offset + 75, y_offset + 50);
-    try path.lineTo(alloc, x_offset + 70, y_offset + 70);
-    try path.lineTo(alloc, x_offset + 55, y_offset + 60);
+    try context.moveTo(x_offset + 110, y_offset + 120);
+    try context.lineTo(x_offset + 20, y_offset + 110);
+    try context.lineTo(x_offset + 10, y_offset + 10);
+    try context.lineTo(x_offset + 110, y_offset + 20);
+    try context.lineTo(x_offset + 100, y_offset + 100);
+    try context.lineTo(x_offset + 30, y_offset + 90);
+    try context.lineTo(x_offset + 25, y_offset + 30);
+    try context.lineTo(x_offset + 90, y_offset + 35);
+    try context.lineTo(x_offset + 90, y_offset + 80);
+    try context.lineTo(x_offset + 40, y_offset + 80);
+    try context.lineTo(x_offset + 45, y_offset + 45);
+    try context.lineTo(x_offset + 75, y_offset + 50);
+    try context.lineTo(x_offset + 70, y_offset + 70);
+    try context.lineTo(x_offset + 55, y_offset + 60);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/016_fill_star_non_zero.zig
+++ b/spec/016_fill_star_non_zero.zig
@@ -14,35 +14,27 @@ pub const filename = "016_fill_star_non_zero";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .fill_rule = .non_zero,
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setFillRule(.non_zero);
 
     const margin = 20;
     const x_scale = 3;
     const y_scale = 5;
     // With all 5 points numbered 1-5 clockwise, we draw odds first (1, 3, 5),
     // then evens (4, 2), with the close connecting 4 and 1.
-    try path.moveTo(alloc, width / 2, 0 + margin); // 1
-    try path.lineTo(alloc, width - margin * x_scale - 1, height - margin - 1); // 3
-    try path.lineTo(alloc, 0 + margin, 0 + margin * y_scale); // 5
-    try path.lineTo(alloc, width - margin - 1, 0 + margin * y_scale); // 2
-    try path.lineTo(alloc, 0 + margin * x_scale, height - margin - 1); // 4
-    try path.close(alloc);
+    try context.moveTo(width / 2, 0 + margin); // 1
+    try context.lineTo(width - margin * x_scale - 1, height - margin - 1); // 3
+    try context.lineTo(0 + margin, 0 + margin * y_scale); // 5
+    try context.lineTo(width - margin - 1, 0 + margin * y_scale); // 2
+    try context.lineTo(0 + margin * x_scale, height - margin - 1); // 4
+    try context.close();
 
-    try context.fill(alloc, path);
+    try context.fill();
 
     return sfc;
 }

--- a/spec/017_stroke_star_round.zig
+++ b/spec/017_stroke_star_round.zig
@@ -11,36 +11,28 @@ pub const filename = "017_stroke_star_round";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .line_width = 10,
-        .line_join_mode = .round,
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(10);
+    context.setLineJoinMode(.round);
 
     const margin = 20;
     const x_scale = 3;
     const y_scale = 5;
     // With all 5 points numbered 1-5 clockwise, we draw odds first (1, 3, 5),
     // then evens (4, 2), with the close connecting 4 and 1.
-    try path.moveTo(alloc, width / 2, 0 + margin); // 1
-    try path.lineTo(alloc, width - margin * x_scale - 1, height - margin - 1); // 3
-    try path.lineTo(alloc, 0 + margin, 0 + margin * y_scale); // 5
-    try path.lineTo(alloc, width - margin - 1, 0 + margin * y_scale); // 2
-    try path.lineTo(alloc, 0 + margin * x_scale, height - margin - 1); // 4
-    try path.close(alloc);
+    try context.moveTo(width / 2, 0 + margin); // 1
+    try context.lineTo(width - margin * x_scale - 1, height - margin - 1); // 3
+    try context.lineTo(0 + margin, 0 + margin * y_scale); // 5
+    try context.lineTo(width - margin - 1, 0 + margin * y_scale); // 2
+    try context.lineTo(0 + margin * x_scale, height - margin - 1); // 4
+    try context.close();
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/018_stroke_square_spiral_round.zig
+++ b/spec/018_stroke_square_spiral_round.zig
@@ -11,92 +11,84 @@ pub const filename = "018_stroke_square_spiral_round";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 240;
     const height = 260;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .line_width = 10,
-        .line_join_mode = .round,
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(10);
+    context.setLineJoinMode(.round);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
-
-    try path.moveTo(alloc, 10, 10);
-    try path.lineTo(alloc, 100, 20);
-    try path.lineTo(alloc, 110, 120);
-    try path.lineTo(alloc, 10, 110);
-    try path.lineTo(alloc, 20, 30);
-    try path.lineTo(alloc, 90, 40);
-    try path.lineTo(alloc, 95, 100);
-    try path.lineTo(alloc, 30, 95);
-    try path.lineTo(alloc, 30, 50);
-    try path.lineTo(alloc, 80, 50);
-    try path.lineTo(alloc, 75, 85);
-    try path.lineTo(alloc, 45, 80);
-    try path.lineTo(alloc, 50, 60);
-    try path.lineTo(alloc, 65, 70);
+    try context.moveTo(10, 10);
+    try context.lineTo(100, 20);
+    try context.lineTo(110, 120);
+    try context.lineTo(10, 110);
+    try context.lineTo(20, 30);
+    try context.lineTo(90, 40);
+    try context.lineTo(95, 100);
+    try context.lineTo(30, 95);
+    try context.lineTo(30, 50);
+    try context.lineTo(80, 50);
+    try context.lineTo(75, 85);
+    try context.lineTo(45, 80);
+    try context.lineTo(50, 60);
+    try context.lineTo(65, 70);
 
     ////////////////////
     const x_offset = 120;
 
-    try path.moveTo(alloc, x_offset + 110, 10);
-    try path.lineTo(alloc, x_offset + 20, 20);
-    try path.lineTo(alloc, x_offset + 10, 120);
-    try path.lineTo(alloc, x_offset + 110, 110);
-    try path.lineTo(alloc, x_offset + 100, 30);
-    try path.lineTo(alloc, x_offset + 30, 40);
-    try path.lineTo(alloc, x_offset + 25, 100);
-    try path.lineTo(alloc, x_offset + 90, 95);
-    try path.lineTo(alloc, x_offset + 90, 50);
-    try path.lineTo(alloc, x_offset + 40, 50);
-    try path.lineTo(alloc, x_offset + 45, 85);
-    try path.lineTo(alloc, x_offset + 75, 80);
-    try path.lineTo(alloc, x_offset + 70, 60);
-    try path.lineTo(alloc, x_offset + 55, 70);
+    try context.moveTo(x_offset + 110, 10);
+    try context.lineTo(x_offset + 20, 20);
+    try context.lineTo(x_offset + 10, 120);
+    try context.lineTo(x_offset + 110, 110);
+    try context.lineTo(x_offset + 100, 30);
+    try context.lineTo(x_offset + 30, 40);
+    try context.lineTo(x_offset + 25, 100);
+    try context.lineTo(x_offset + 90, 95);
+    try context.lineTo(x_offset + 90, 50);
+    try context.lineTo(x_offset + 40, 50);
+    try context.lineTo(x_offset + 45, 85);
+    try context.lineTo(x_offset + 75, 80);
+    try context.lineTo(x_offset + 70, 60);
+    try context.lineTo(x_offset + 55, 70);
 
     ////////////////////
     const y_offset = 130;
 
-    try path.moveTo(alloc, 10, y_offset + 120);
-    try path.lineTo(alloc, 100, y_offset + 110);
-    try path.lineTo(alloc, 110, y_offset + 10);
-    try path.lineTo(alloc, 10, y_offset + 20);
-    try path.lineTo(alloc, 20, y_offset + 100);
-    try path.lineTo(alloc, 90, y_offset + 90);
-    try path.lineTo(alloc, 95, y_offset + 30);
-    try path.lineTo(alloc, 30, y_offset + 35);
-    try path.lineTo(alloc, 30, y_offset + 80);
-    try path.lineTo(alloc, 80, y_offset + 80);
-    try path.lineTo(alloc, 75, y_offset + 45);
-    try path.lineTo(alloc, 45, y_offset + 50);
-    try path.lineTo(alloc, 50, y_offset + 70);
-    try path.lineTo(alloc, 65, y_offset + 60);
+    try context.moveTo(10, y_offset + 120);
+    try context.lineTo(100, y_offset + 110);
+    try context.lineTo(110, y_offset + 10);
+    try context.lineTo(10, y_offset + 20);
+    try context.lineTo(20, y_offset + 100);
+    try context.lineTo(90, y_offset + 90);
+    try context.lineTo(95, y_offset + 30);
+    try context.lineTo(30, y_offset + 35);
+    try context.lineTo(30, y_offset + 80);
+    try context.lineTo(80, y_offset + 80);
+    try context.lineTo(75, y_offset + 45);
+    try context.lineTo(45, y_offset + 50);
+    try context.lineTo(50, y_offset + 70);
+    try context.lineTo(65, y_offset + 60);
 
     ////////////////////
 
-    try path.moveTo(alloc, x_offset + 110, y_offset + 120);
-    try path.lineTo(alloc, x_offset + 20, y_offset + 110);
-    try path.lineTo(alloc, x_offset + 10, y_offset + 10);
-    try path.lineTo(alloc, x_offset + 110, y_offset + 20);
-    try path.lineTo(alloc, x_offset + 100, y_offset + 100);
-    try path.lineTo(alloc, x_offset + 30, y_offset + 90);
-    try path.lineTo(alloc, x_offset + 25, y_offset + 30);
-    try path.lineTo(alloc, x_offset + 90, y_offset + 35);
-    try path.lineTo(alloc, x_offset + 90, y_offset + 80);
-    try path.lineTo(alloc, x_offset + 40, y_offset + 80);
-    try path.lineTo(alloc, x_offset + 45, y_offset + 45);
-    try path.lineTo(alloc, x_offset + 75, y_offset + 50);
-    try path.lineTo(alloc, x_offset + 70, y_offset + 70);
-    try path.lineTo(alloc, x_offset + 55, y_offset + 60);
+    try context.moveTo(x_offset + 110, y_offset + 120);
+    try context.lineTo(x_offset + 20, y_offset + 110);
+    try context.lineTo(x_offset + 10, y_offset + 10);
+    try context.lineTo(x_offset + 110, y_offset + 20);
+    try context.lineTo(x_offset + 100, y_offset + 100);
+    try context.lineTo(x_offset + 30, y_offset + 90);
+    try context.lineTo(x_offset + 25, y_offset + 30);
+    try context.lineTo(x_offset + 90, y_offset + 35);
+    try context.lineTo(x_offset + 90, y_offset + 80);
+    try context.lineTo(x_offset + 40, y_offset + 80);
+    try context.lineTo(x_offset + 45, y_offset + 45);
+    try context.lineTo(x_offset + 75, y_offset + 50);
+    try context.lineTo(x_offset + 70, y_offset + 70);
+    try context.lineTo(x_offset + 55, y_offset + 60);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/019_stroke_bevel_miterlimit.zig
+++ b/spec/019_stroke_bevel_miterlimit.zig
@@ -12,19 +12,14 @@ pub const filename = "019_stroke_bevel_miterlimit";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 375;
     const height = 560;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .line_width = 5,
-        .line_join_mode = .bevel,
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(5);
+    context.setLineJoinMode(.bevel);
 
     // We render 5 different paths with increasingly smaller angles to help
     // detect the miter threshold. Our base case (the first), however, uses all
@@ -35,161 +30,159 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     // NOTE: This does not test the default miter limit as it's very high (11
     // degrees, and you can see how tight even 18 degrees is here). We probably
     // should test the default limit via unit testing.
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
-
+    //
     // Line 1, ~130 degrees (dx = 70)
-    try path.moveTo(alloc, 10, 90);
-    try path.lineTo(alloc, 80, 60);
-    try path.lineTo(alloc, 150, 90);
+    try context.moveTo(10, 90);
+    try context.lineTo(80, 60);
+    try context.lineTo(150, 90);
 
     // Line 2, ~99 degrees (dx = 35)
-    try path.moveTo(alloc, 170, 90);
-    try path.lineTo(alloc, 205, 60);
-    try path.lineTo(alloc, 240, 90);
+    try context.moveTo(170, 90);
+    try context.lineTo(205, 60);
+    try context.lineTo(240, 90);
 
     // Line 3, ~67 degrees (dx = 20)
-    try path.moveTo(alloc, 260, 90);
-    try path.lineTo(alloc, 280, 60);
-    try path.lineTo(alloc, 300, 90);
+    try context.moveTo(260, 90);
+    try context.lineTo(280, 60);
+    try context.lineTo(300, 90);
 
     // Line 4, ~28 degrees (dx = 7.5)
-    try path.moveTo(alloc, 320, 90);
-    try path.lineTo(alloc, 327.5, 60);
-    try path.lineTo(alloc, 335, 90);
+    try context.moveTo(320, 90);
+    try context.lineTo(327.5, 60);
+    try context.lineTo(335, 90);
 
     // Line 5, ~18 degrees (dx = 5)
-    try path.moveTo(alloc, 355, 90);
-    try path.lineTo(alloc, 360, 60);
-    try path.lineTo(alloc, 365, 90);
+    try context.moveTo(355, 90);
+    try context.lineTo(360, 60);
+    try context.lineTo(365, 90);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     // First miter case, rendered with a miter limit of 4. Note that this is
     // the SVG default (see the MDN page quoted higher up).
-    context.line_join_mode = .miter;
-    context.miter_limit = 4;
-    path.reset();
+    context.setLineJoinMode(.miter);
+    context.setMiterLimit(4);
+    context.resetPath();
 
     // Line 1, ~130 degrees (dx = 70)
-    try path.moveTo(alloc, 10, 190);
-    try path.lineTo(alloc, 80, 160);
-    try path.lineTo(alloc, 150, 190);
+    try context.moveTo(10, 190);
+    try context.lineTo(80, 160);
+    try context.lineTo(150, 190);
 
     // Line 2, ~99 degrees (dx = 35)
-    try path.moveTo(alloc, 170, 190);
-    try path.lineTo(alloc, 205, 160);
-    try path.lineTo(alloc, 240, 190);
+    try context.moveTo(170, 190);
+    try context.lineTo(205, 160);
+    try context.lineTo(240, 190);
 
     // Line 3, ~67 degrees (dx = 20)
-    try path.moveTo(alloc, 260, 190);
-    try path.lineTo(alloc, 280, 160);
-    try path.lineTo(alloc, 300, 190);
+    try context.moveTo(260, 190);
+    try context.lineTo(280, 160);
+    try context.lineTo(300, 190);
 
     // Line 4, ~28 degrees (dx = 7.5)
-    try path.moveTo(alloc, 320, 190);
-    try path.lineTo(alloc, 327.5, 160);
-    try path.lineTo(alloc, 335, 190);
+    try context.moveTo(320, 190);
+    try context.lineTo(327.5, 160);
+    try context.lineTo(335, 190);
 
     // Line 5, ~18 degrees (dx = 5)
-    try path.moveTo(alloc, 355, 190);
-    try path.lineTo(alloc, 360, 160);
-    try path.lineTo(alloc, 365, 190);
+    try context.moveTo(355, 190);
+    try context.lineTo(360, 160);
+    try context.lineTo(365, 190);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     // Second miter case, rendered with a miter limit of 1
-    context.miter_limit = 1;
-    path.reset();
+    context.setMiterLimit(1);
+    context.resetPath();
 
     // Line 1, ~130 degrees (dx = 70)
-    try path.moveTo(alloc, 10, 290);
-    try path.lineTo(alloc, 80, 260);
-    try path.lineTo(alloc, 150, 290);
+    try context.moveTo(10, 290);
+    try context.lineTo(80, 260);
+    try context.lineTo(150, 290);
 
     // Line 2, ~99 degrees (dx = 35)
-    try path.moveTo(alloc, 170, 290);
-    try path.lineTo(alloc, 205, 260);
-    try path.lineTo(alloc, 240, 290);
+    try context.moveTo(170, 290);
+    try context.lineTo(205, 260);
+    try context.lineTo(240, 290);
 
     // Line 3, ~67 degrees (dx = 20)
-    try path.moveTo(alloc, 260, 290);
-    try path.lineTo(alloc, 280, 260);
-    try path.lineTo(alloc, 300, 290);
+    try context.moveTo(260, 290);
+    try context.lineTo(280, 260);
+    try context.lineTo(300, 290);
 
     // Line 4, ~28 degrees (dx = 7.5)
-    try path.moveTo(alloc, 320, 290);
-    try path.lineTo(alloc, 327.5, 260);
-    try path.lineTo(alloc, 335, 290);
+    try context.moveTo(320, 290);
+    try context.lineTo(327.5, 260);
+    try context.lineTo(335, 290);
 
     // Line 5, ~18 degrees (dx = 5)
-    try path.moveTo(alloc, 355, 290);
-    try path.lineTo(alloc, 360, 260);
-    try path.lineTo(alloc, 365, 290);
+    try context.moveTo(355, 290);
+    try context.lineTo(360, 260);
+    try context.lineTo(365, 290);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     // Third miter case, rendered with a miter limit of 6
-    context.miter_limit = 6;
-    path.reset();
+    context.setMiterLimit(6);
+    context.resetPath();
 
     // Line 1, ~130 degrees (dx = 70)
-    try path.moveTo(alloc, 10, 390);
-    try path.lineTo(alloc, 80, 360);
-    try path.lineTo(alloc, 150, 390);
+    try context.moveTo(10, 390);
+    try context.lineTo(80, 360);
+    try context.lineTo(150, 390);
 
     // Line 2, ~99 degrees (dx = 35)
-    try path.moveTo(alloc, 170, 390);
-    try path.lineTo(alloc, 205, 360);
-    try path.lineTo(alloc, 240, 390);
+    try context.moveTo(170, 390);
+    try context.lineTo(205, 360);
+    try context.lineTo(240, 390);
 
     // Line 3, ~67 degrees (dx = 20)
-    try path.moveTo(alloc, 260, 390);
-    try path.lineTo(alloc, 280, 360);
-    try path.lineTo(alloc, 300, 390);
+    try context.moveTo(260, 390);
+    try context.lineTo(280, 360);
+    try context.lineTo(300, 390);
 
     // Line 4, ~28 degrees (dx = 7.5)
-    try path.moveTo(alloc, 320, 390);
-    try path.lineTo(alloc, 327.5, 360);
-    try path.lineTo(alloc, 335, 390);
+    try context.moveTo(320, 390);
+    try context.lineTo(327.5, 360);
+    try context.lineTo(335, 390);
 
     // Line 5, ~18 degrees (dx = 5)
-    try path.moveTo(alloc, 355, 390);
-    try path.lineTo(alloc, 360, 360);
-    try path.lineTo(alloc, 365, 390);
+    try context.moveTo(355, 390);
+    try context.lineTo(360, 360);
+    try context.lineTo(365, 390);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     // Fourth miter case, rendered with a miter limit of 10 (default)
-    context.miter_limit = 10;
-    path.reset();
+    context.setMiterLimit(10);
+    context.resetPath();
 
     // Line 1, ~130 degrees (dx = 70)
-    try path.moveTo(alloc, 10, 490);
-    try path.lineTo(alloc, 80, 460);
-    try path.lineTo(alloc, 150, 490);
+    try context.moveTo(10, 490);
+    try context.lineTo(80, 460);
+    try context.lineTo(150, 490);
 
     // Line 2, ~99 degrees (dx = 35)
-    try path.moveTo(alloc, 170, 490);
-    try path.lineTo(alloc, 205, 460);
-    try path.lineTo(alloc, 240, 490);
+    try context.moveTo(170, 490);
+    try context.lineTo(205, 460);
+    try context.lineTo(240, 490);
 
     // Line 3, ~67 degrees (dx = 20)
-    try path.moveTo(alloc, 260, 490);
-    try path.lineTo(alloc, 280, 460);
-    try path.lineTo(alloc, 300, 490);
+    try context.moveTo(260, 490);
+    try context.lineTo(280, 460);
+    try context.lineTo(300, 490);
 
     // Line 4, ~28 degrees (dx = 7.5)
-    try path.moveTo(alloc, 320, 490);
-    try path.lineTo(alloc, 327.5, 460);
-    try path.lineTo(alloc, 335, 490);
+    try context.moveTo(320, 490);
+    try context.lineTo(327.5, 460);
+    try context.lineTo(335, 490);
 
     // Line 5, ~18 degrees (dx = 5)
-    try path.moveTo(alloc, 355, 490);
-    try path.lineTo(alloc, 360, 460);
-    try path.lineTo(alloc, 365, 490);
+    try context.moveTo(355, 490);
+    try context.lineTo(360, 460);
+    try context.lineTo(365, 490);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/020_stroke_lines_round_caps.zig
+++ b/spec/020_stroke_lines_round_caps.zig
@@ -11,23 +11,15 @@ pub const filename = "020_stroke_lines_round_caps";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 800;
     const height = 600;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .line_cap_mode = .round,
-        .line_join_mode = .round,
-        .line_width = 20,
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineCapMode(.round);
+    context.setLineJoinMode(.round);
+    context.setLineWidth(20);
 
     // sub-canvas dimensions
     const sub_canvas_width = width / 4;
@@ -37,97 +29,97 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     const margin = 30;
     var x_offset: f64 = 0;
     var y_offset: f64 = 0;
-    try path.moveTo(alloc, x_offset + margin, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + margin, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
 
     // Up and to the right
     x_offset = sub_canvas_width;
-    try path.moveTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.moveTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
 
     // Down and to the left
     x_offset = 0;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
 
     // Up and to the left
     x_offset = sub_canvas_width;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + margin, y_offset + margin);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + margin, y_offset + margin);
 
     // Horizontal (left -> right)
     x_offset = sub_canvas_width * 2;
     y_offset = 0;
-    try path.moveTo(alloc, x_offset + margin, y_offset + sub_canvas_height / 2);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
+    try context.moveTo(x_offset + margin, y_offset + sub_canvas_height / 2);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
 
     // Vertical (up -> down)
     x_offset = sub_canvas_width * 2;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width / 2, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + sub_canvas_width / 2, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
 
     // Vertical (down -> up)
     x_offset = sub_canvas_width * 3;
     y_offset = 0;
-    try path.moveTo(alloc, x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2, y_offset + margin);
+    try context.moveTo(x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width / 2, y_offset + margin);
 
     // Horizontal (right -> left)
     x_offset = sub_canvas_width * 3;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height / 2);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height / 2);
 
     // Joined, clockwise
     x_offset = 0;
     y_offset = sub_canvas_height * 2;
-    try path.moveTo(alloc, x_offset + margin, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2 - 1);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + margin, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2 - 1);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
 
     // Joined, counter-clockwise
     x_offset = sub_canvas_width;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height / 2 - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height / 2 - 1);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
 
     // Joined, clockwise up-down, down-up
     x_offset = sub_canvas_width * 2;
     sub_canvas_height = sub_canvas_height / 2;
-    try path.moveTo(alloc, x_offset + margin, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2 - 1, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.moveTo(x_offset + margin, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width / 2 - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
 
     // Joined, clockwise down-up, up-down
     x_offset = sub_canvas_width * 3;
-    try path.moveTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2 - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width / 2 - 1, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
 
     // Joined, counter-clockwise, down-up, up-down
     x_offset = sub_canvas_width * 2;
     y_offset = y_offset + sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2 - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width / 2 - 1, y_offset + margin);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
 
     // Joined, counter-clockwise, up-down, down-up
     x_offset = sub_canvas_width * 3;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2 - 1, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + margin, y_offset + margin);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width / 2 - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + margin, y_offset + margin);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     // We draw a hairline in the same path in red - this validates how the caps
     // and joins are aligned.
-    context.pattern.opaque_pattern.pixel = .{ .rgb = .{ .r = 0xF3, .g = 0x00, .b = 0x00 } }; // Red
-    context.line_width = 1;
+    context.setSource(.{ .rgb = .{ .r = 0xF3, .g = 0x00, .b = 0x00 } });
+    context.setLineWidth(1);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/021_stroke_lines_square_caps.zig
+++ b/spec/021_stroke_lines_square_caps.zig
@@ -11,22 +11,14 @@ pub const filename = "021_stroke_lines_square_caps";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 800;
     const height = 600;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .line_cap_mode = .square,
-        .line_width = 20,
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineCapMode(.square);
+    context.setLineWidth(20);
 
     // sub-canvas dimensions
     const sub_canvas_width = width / 4;
@@ -36,97 +28,97 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     const margin = 30;
     var x_offset: f64 = 0;
     var y_offset: f64 = 0;
-    try path.moveTo(alloc, x_offset + margin, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + margin, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
 
     // Up and to the right
     x_offset = sub_canvas_width;
-    try path.moveTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.moveTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
 
     // Down and to the left
     x_offset = 0;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
 
     // Up and to the left
     x_offset = sub_canvas_width;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + margin, y_offset + margin);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + margin, y_offset + margin);
 
     // Horizontal (left -> right)
     x_offset = sub_canvas_width * 2;
     y_offset = 0;
-    try path.moveTo(alloc, x_offset + margin, y_offset + sub_canvas_height / 2);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
+    try context.moveTo(x_offset + margin, y_offset + sub_canvas_height / 2);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
 
     // Vertical (up -> down)
     x_offset = sub_canvas_width * 2;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width / 2, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + sub_canvas_width / 2, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
 
     // Vertical (down -> up)
     x_offset = sub_canvas_width * 3;
     y_offset = 0;
-    try path.moveTo(alloc, x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2, y_offset + margin);
+    try context.moveTo(x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width / 2, y_offset + margin);
 
     // Horizontal (right -> left)
     x_offset = sub_canvas_width * 3;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height / 2);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height / 2);
 
     // Joined, clockwise
     x_offset = 0;
     y_offset = sub_canvas_height * 2;
-    try path.moveTo(alloc, x_offset + margin, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2 - 1);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + margin, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2 - 1);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
 
     // Joined, counter-clockwise
     x_offset = sub_canvas_width;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height / 2 - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height / 2 - 1);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
 
     // Joined, clockwise up-down, down-up
     x_offset = sub_canvas_width * 2;
     sub_canvas_height = sub_canvas_height / 2;
-    try path.moveTo(alloc, x_offset + margin, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2 - 1, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.moveTo(x_offset + margin, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width / 2 - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
 
     // Joined, clockwise down-up, up-down
     x_offset = sub_canvas_width * 3;
-    try path.moveTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2 - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width / 2 - 1, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
 
     // Joined, counter-clockwise, down-up, up-down
     x_offset = sub_canvas_width * 2;
     y_offset = y_offset + sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2 - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width / 2 - 1, y_offset + margin);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
 
     // Joined, counter-clockwise, up-down, down-up
     x_offset = sub_canvas_width * 3;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2 - 1, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + margin, y_offset + margin);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width / 2 - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + margin, y_offset + margin);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     // We draw a hairline in the same path in red - this validates how the caps
     // and joins are aligned.
-    context.pattern.opaque_pattern.pixel = .{ .rgb = .{ .r = 0xF3, .g = 0x00, .b = 0x00 } }; // Red
-    context.line_width = 1;
+    context.setSource(.{ .rgb = .{ .r = 0xF3, .g = 0x00, .b = 0x00 } });
+    context.setLineWidth(1);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/022_stroke_lines_butt_caps.zig
+++ b/spec/022_stroke_lines_butt_caps.zig
@@ -11,22 +11,14 @@ pub const filename = "022_stroke_lines_butt_caps";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 800;
     const height = 600;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .line_cap_mode = .butt,
-        .line_width = 20,
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineCapMode(.butt);
+    context.setLineWidth(20);
 
     // sub-canvas dimensions
     const sub_canvas_width = width / 4;
@@ -36,97 +28,97 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     const margin = 30;
     var x_offset: f64 = 0;
     var y_offset: f64 = 0;
-    try path.moveTo(alloc, x_offset + margin, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + margin, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
 
     // Up and to the right
     x_offset = sub_canvas_width;
-    try path.moveTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.moveTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
 
     // Down and to the left
     x_offset = 0;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
 
     // Up and to the left
     x_offset = sub_canvas_width;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + margin, y_offset + margin);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + margin, y_offset + margin);
 
     // Horizontal (left -> right)
     x_offset = sub_canvas_width * 2;
     y_offset = 0;
-    try path.moveTo(alloc, x_offset + margin, y_offset + sub_canvas_height / 2);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
+    try context.moveTo(x_offset + margin, y_offset + sub_canvas_height / 2);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
 
     // Vertical (up -> down)
     x_offset = sub_canvas_width * 2;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width / 2, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + sub_canvas_width / 2, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
 
     // Vertical (down -> up)
     x_offset = sub_canvas_width * 3;
     y_offset = 0;
-    try path.moveTo(alloc, x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2, y_offset + margin);
+    try context.moveTo(x_offset + sub_canvas_width / 2, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width / 2, y_offset + margin);
 
     // Horizontal (right -> left)
     x_offset = sub_canvas_width * 3;
     y_offset = sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height / 2);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height / 2);
 
     // Joined, clockwise
     x_offset = 0;
     y_offset = sub_canvas_height * 2;
-    try path.moveTo(alloc, x_offset + margin, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2 - 1);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + margin, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height / 2 - 1);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
 
     // Joined, counter-clockwise
     x_offset = sub_canvas_width;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height / 2 - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height / 2 - 1);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
 
     // Joined, clockwise up-down, down-up
     x_offset = sub_canvas_width * 2;
     sub_canvas_height = sub_canvas_height / 2;
-    try path.moveTo(alloc, x_offset + margin, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2 - 1, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.moveTo(x_offset + margin, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width / 2 - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
 
     // Joined, clockwise down-up, up-down
     x_offset = sub_canvas_width * 3;
-    try path.moveTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2 - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width / 2 - 1, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
 
     // Joined, counter-clockwise, down-up, up-down
     x_offset = sub_canvas_width * 2;
     y_offset = y_offset + sub_canvas_height;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2 - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + margin, y_offset + sub_canvas_height - margin - 1);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + sub_canvas_width / 2 - 1, y_offset + margin);
+    try context.lineTo(x_offset + margin, y_offset + sub_canvas_height - margin - 1);
 
     // Joined, counter-clockwise, up-down, down-up
     x_offset = sub_canvas_width * 3;
-    try path.moveTo(alloc, x_offset + sub_canvas_width - margin - 1, y_offset + margin);
-    try path.lineTo(alloc, x_offset + sub_canvas_width / 2 - 1, y_offset + sub_canvas_height - margin - 1);
-    try path.lineTo(alloc, x_offset + margin, y_offset + margin);
+    try context.moveTo(x_offset + sub_canvas_width - margin - 1, y_offset + margin);
+    try context.lineTo(x_offset + sub_canvas_width / 2 - 1, y_offset + sub_canvas_height - margin - 1);
+    try context.lineTo(x_offset + margin, y_offset + margin);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     // We draw a hairline in the same path in red - this validates how the caps
     // and joins are aligned.
-    context.pattern.opaque_pattern.pixel = .{ .rgb = .{ .r = 0xF3, .g = 0x00, .b = 0x00 } }; // Red
-    context.line_width = 1;
+    context.setSource(.{ .rgb = .{ .r = 0xF3, .g = 0x00, .b = 0x00 } });
+    context.setLineWidth(1);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/024_fill_triangle_direct_cross_format.zig
+++ b/spec/024_fill_triangle_direct_cross_format.zig
@@ -13,28 +13,20 @@ pub const filename = "024_fill_triangle_direct_cross_format";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgba = .{ .r = 0xFF, .g = 0x8a, .b = 0xa5, .a = 0xFF } }, // Bubblegum!
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgba = .{ .r = 0xFF, .g = 0x8a, .b = 0xa5, .a = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
     const margin = 10;
-    try path.moveTo(alloc, 0 + margin, 0 + margin);
-    try path.lineTo(alloc, width - margin - 1, 0 + margin);
-    try path.lineTo(alloc, width / 2 - 1, height - margin - 1);
-    try path.close(alloc);
+    try context.moveTo(0 + margin, 0 + margin);
+    try context.lineTo(width - margin - 1, 0 + margin);
+    try context.lineTo(width / 2 - 1, height - margin - 1);
+    try context.close();
 
-    try context.fill(alloc, path);
+    try context.fill();
 
     return sfc;
 }

--- a/spec/025_fill_diamond_clipped.zig
+++ b/spec/025_fill_diamond_clipped.zig
@@ -11,28 +11,20 @@ pub const filename = "025_fill_diamond_clipped";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    try context.moveTo(width / 2, 0 - height / 10);
+    try context.lineTo(width + width / 10, height / 2);
+    try context.lineTo(width / 2, height + height / 10);
+    try context.lineTo(0 - width / 10, height / 2);
+    try context.close();
 
-    try path.moveTo(alloc, width / 2, 0 - height / 10);
-    try path.lineTo(alloc, width + width / 10, height / 2);
-    try path.lineTo(alloc, width / 2, height + height / 10);
-    try path.lineTo(alloc, 0 - width / 10, height / 2);
-    try path.close(alloc);
-
-    try context.fill(alloc, path);
+    try context.fill();
 
     return sfc;
 }

--- a/spec/026_fill_triangle_full.zig
+++ b/spec/026_fill_triangle_full.zig
@@ -12,27 +12,19 @@ pub const filename = "026_fill_triangle_full";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    try context.moveTo(0, 0);
+    try context.lineTo(width, 0);
+    try context.lineTo(width / 2, height);
+    try context.close();
 
-    try path.moveTo(alloc, 0, 0);
-    try path.lineTo(alloc, width, 0);
-    try path.lineTo(alloc, width / 2, height);
-    try path.close(alloc);
-
-    try context.fill(alloc, path);
+    try context.fill();
 
     return sfc;
 }

--- a/spec/027_stroke_bezier_tolerance.zig
+++ b/spec/027_stroke_bezier_tolerance.zig
@@ -14,37 +14,29 @@ pub const filename = "027_bezier_tolerance";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(5);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
-    context.line_width = 5;
+    try context.moveTo(19, 149);
+    try context.curveTo(89, 0, 209, 0, 279, 149);
+    try context.stroke();
 
-    try path.moveTo(alloc, 19, 149);
-    try path.curveTo(alloc, 89, 0, 209, 0, 279, 149);
-    try context.stroke(alloc, path);
+    context.setTolerance(3);
+    context.resetPath();
+    try context.moveTo(19, 199);
+    try context.curveTo(89, 24, 209, 24, 279, 199);
+    try context.stroke();
 
-    context.tolerance = 3;
-    path.reset();
-    try path.moveTo(alloc, 19, 199);
-    try path.curveTo(alloc, 89, 24, 209, 24, 279, 199);
-    try context.stroke(alloc, path);
-
-    context.tolerance = 10;
-    path.reset();
-    try path.moveTo(alloc, 19, 249);
-    try path.curveTo(alloc, 89, 49, 209, 49, 279, 249);
-    try context.stroke(alloc, path);
+    context.setTolerance(10);
+    context.resetPath();
+    try context.moveTo(19, 249);
+    try context.curveTo(89, 49, 209, 49, 279, 249);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/028_fill_bezier_tolerance.zig
+++ b/spec/028_fill_bezier_tolerance.zig
@@ -13,40 +13,32 @@ pub const filename = "028_fill_bezier_tolerance";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 900;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(5);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
-    context.line_width = 5;
+    try context.moveTo(19, 224);
+    try context.curveTo(89, 49, 209, 49, 279, 224);
+    try context.close();
+    try context.fill();
 
-    try path.moveTo(alloc, 19, 224);
-    try path.curveTo(alloc, 89, 49, 209, 49, 279, 224);
-    try path.close(alloc);
-    try context.fill(alloc, path);
+    context.setTolerance(3);
+    context.resetPath();
+    try context.moveTo(319, 224);
+    try context.curveTo(389, 49, 509, 49, 579, 224);
+    try context.close();
+    try context.fill();
 
-    context.tolerance = 3;
-    path.reset();
-    try path.moveTo(alloc, 319, 224);
-    try path.curveTo(alloc, 389, 49, 509, 49, 579, 224);
-    try path.close(alloc);
-    try context.fill(alloc, path);
-
-    context.tolerance = 10;
-    path.reset();
-    try path.moveTo(alloc, 619, 224);
-    try path.curveTo(alloc, 689, 49, 809, 49, 879, 224);
-    try path.close(alloc);
-    try context.fill(alloc, path);
+    context.setTolerance(10);
+    context.resetPath();
+    try context.moveTo(619, 224);
+    try context.curveTo(689, 49, 809, 49, 879, 224);
+    try context.close();
+    try context.fill();
 
     return sfc;
 }

--- a/spec/029_stroke_lines_round_caps_tolerance.zig
+++ b/spec/029_stroke_lines_round_caps_tolerance.zig
@@ -11,39 +11,31 @@ pub const filename = "029_stroke_lines_round_caps_tolerance";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .line_cap_mode = .round,
-        .line_join_mode = .round,
-        .line_width = 30,
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineCapMode(.round);
+    context.setLineJoinMode(.round);
+    context.setLineWidth(30);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    try context.moveTo(30, 50);
+    try context.lineTo(270, 50);
+    try context.stroke();
 
-    try path.moveTo(alloc, 30, 50);
-    try path.lineTo(alloc, 270, 50);
-    try context.stroke(alloc, path);
+    context.setTolerance(3);
+    context.resetPath();
+    try context.moveTo(30, 150);
+    try context.lineTo(270, 150);
+    try context.stroke();
 
-    context.tolerance = 3;
-    path.reset();
-    try path.moveTo(alloc, 30, 150);
-    try path.lineTo(alloc, 270, 150);
-    try context.stroke(alloc, path);
-
-    context.tolerance = 10;
-    path.reset();
-    try path.moveTo(alloc, 30, 250);
-    try path.lineTo(alloc, 270, 250);
-    try context.stroke(alloc, path);
+    context.setTolerance(10);
+    context.resetPath();
+    try context.moveTo(30, 250);
+    try context.lineTo(270, 250);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/030_stroke_star_round_tolerance.zig
+++ b/spec/030_stroke_star_round_tolerance.zig
@@ -12,22 +12,14 @@ pub const filename = "030_stroke_star_round_tolerance";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 900;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .line_width = 30,
-        .line_join_mode = .round,
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(30);
+    context.setLineJoinMode(.round);
 
     const margin = 20;
     const sub_canvas_width = 300;
@@ -35,35 +27,35 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     const y_scale = 5;
     // With all 5 points numbered 1-5 clockwise, we draw odds first (1, 3, 5),
     // then evens (4, 2), with the close connecting 4 and 1.
-    try path.moveTo(alloc, sub_canvas_width / 2, 0 + margin); // 1
-    try path.lineTo(alloc, sub_canvas_width - margin * x_scale - 1, height - margin - 1); // 3
-    try path.lineTo(alloc, 0 + margin, 0 + margin * y_scale); // 5
-    try path.lineTo(alloc, sub_canvas_width - margin - 1, 0 + margin * y_scale); // 2
-    try path.lineTo(alloc, 0 + margin * x_scale, height - margin - 1); // 4
-    try path.close(alloc);
-    try context.stroke(alloc, path);
+    try context.moveTo(sub_canvas_width / 2, 0 + margin); // 1
+    try context.lineTo(sub_canvas_width - margin * x_scale - 1, height - margin - 1); // 3
+    try context.lineTo(0 + margin, 0 + margin * y_scale); // 5
+    try context.lineTo(sub_canvas_width - margin - 1, 0 + margin * y_scale); // 2
+    try context.lineTo(0 + margin * x_scale, height - margin - 1); // 4
+    try context.close();
+    try context.stroke();
 
-    path.reset();
-    context.tolerance = 3;
+    context.resetPath();
+    context.setTolerance(3);
     var x_offset: f64 = 300;
-    try path.moveTo(alloc, x_offset + sub_canvas_width / 2, 0 + margin); // 1
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin * x_scale - 1, height - margin - 1); // 3
-    try path.lineTo(alloc, x_offset + 0 + margin, 0 + margin * y_scale); // 5
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, 0 + margin * y_scale); // 2
-    try path.lineTo(alloc, x_offset + 0 + margin * x_scale, height - margin - 1); // 4
-    try path.close(alloc);
-    try context.stroke(alloc, path);
+    try context.moveTo(x_offset + sub_canvas_width / 2, 0 + margin); // 1
+    try context.lineTo(x_offset + sub_canvas_width - margin * x_scale - 1, height - margin - 1); // 3
+    try context.lineTo(x_offset + 0 + margin, 0 + margin * y_scale); // 5
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, 0 + margin * y_scale); // 2
+    try context.lineTo(x_offset + 0 + margin * x_scale, height - margin - 1); // 4
+    try context.close();
+    try context.stroke();
 
-    path.reset();
-    context.tolerance = 10;
+    context.resetPath();
+    context.setTolerance(10);
     x_offset = 600;
-    try path.moveTo(alloc, x_offset + sub_canvas_width / 2, 0 + margin); // 1
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin * x_scale - 1, height - margin - 1); // 3
-    try path.lineTo(alloc, x_offset + 0 + margin, 0 + margin * y_scale); // 5
-    try path.lineTo(alloc, x_offset + sub_canvas_width - margin - 1, 0 + margin * y_scale); // 2
-    try path.lineTo(alloc, x_offset + 0 + margin * x_scale, height - margin - 1); // 4
-    try path.close(alloc);
-    try context.stroke(alloc, path);
+    try context.moveTo(x_offset + sub_canvas_width / 2, 0 + margin); // 1
+    try context.lineTo(x_offset + sub_canvas_width - margin * x_scale - 1, height - margin - 1); // 3
+    try context.lineTo(x_offset + 0 + margin, 0 + margin * y_scale); // 5
+    try context.lineTo(x_offset + sub_canvas_width - margin - 1, 0 + margin * y_scale); // 2
+    try context.lineTo(x_offset + 0 + margin * x_scale, height - margin - 1); // 4
+    try context.close();
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/031_fill_quad_bezier.zig
+++ b/spec/031_fill_quad_bezier.zig
@@ -23,38 +23,30 @@ pub const filename = "031_fill_quad_bezier";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    try context.moveTo(20, 130);
+    try context.curveTo(20, 130, 20, 20, 130, 20);
+    try context.close();
 
-    try path.moveTo(alloc, 20, 130);
-    try path.curveTo(alloc, 20, 130, 20, 20, 130, 20);
-    try path.close(alloc);
+    try context.moveTo(170, 20);
+    try context.curveTo(280, 20, 280, 20, 280, 130);
+    try context.close();
 
-    try path.moveTo(alloc, 170, 20);
-    try path.curveTo(alloc, 280, 20, 280, 20, 280, 130);
-    try path.close(alloc);
+    try context.moveTo(280, 170);
+    try context.curveTo(280, 280, 170, 280, 170, 280);
+    try context.close();
 
-    try path.moveTo(alloc, 280, 170);
-    try path.curveTo(alloc, 280, 280, 170, 280, 170, 280);
-    try path.close(alloc);
+    try context.moveTo(130, 280);
+    try context.curveTo(20, 280, 20, 280, 20, 170);
+    try context.close();
 
-    try path.moveTo(alloc, 130, 280);
-    try path.curveTo(alloc, 20, 280, 20, 280, 20, 170);
-    try path.close(alloc);
-
-    try context.fill(alloc, path);
+    try context.fill();
 
     return sfc;
 }

--- a/spec/032_fill_arc.zig
+++ b/spec/032_fill_arc.zig
@@ -12,20 +12,12 @@ pub const filename = "032_fill_arc";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
     // For approximating a circle w/bezier
     // https://stackoverflow.com/a/27863181
@@ -37,13 +29,13 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
         const radius = 50;
         const p12 = radius * ratio;
 
-        try path.moveTo(alloc, center_x, center_y - radius);
-        try path.curveTo(alloc, center_x + p12, center_y - radius, center_x + radius, center_y - p12, center_x + radius, center_y);
-        try path.curveTo(alloc, center_x + radius, center_y + p12, center_x + p12, center_y + radius, center_x, center_y + radius);
-        try path.curveTo(alloc, center_x - p12, center_y + radius, center_x - radius, center_y + p12, center_x - radius, center_y);
-        try path.curveTo(alloc, center_x - radius, center_y - p12, center_x - p12, center_y - radius, center_x, center_y - radius);
-        try path.close(alloc);
-        try context.fill(alloc, path);
+        try context.moveTo(center_x, center_y - radius);
+        try context.curveTo(center_x + p12, center_y - radius, center_x + radius, center_y - p12, center_x + radius, center_y);
+        try context.curveTo(center_x + radius, center_y + p12, center_x + p12, center_y + radius, center_x, center_y + radius);
+        try context.curveTo(center_x - p12, center_y + radius, center_x - radius, center_y + p12, center_x - radius, center_y);
+        try context.curveTo(center_x - radius, center_y - p12, center_x - p12, center_y - radius, center_x, center_y - radius);
+        try context.close();
+        try context.fill();
     }
 
     {
@@ -53,14 +45,14 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
         const p12_major = radius_major * ratio;
         const p12_minor = radius_minor * ratio;
 
-        path.reset();
-        try path.moveTo(alloc, center_x, center_y - radius_major);
-        try path.curveTo(alloc, center_x + p12_minor, center_y - radius_major, center_x + radius_minor, center_y - p12_major, center_x + radius_minor, center_y);
-        try path.curveTo(alloc, center_x + radius_minor, center_y + p12_major, center_x + p12_minor, center_y + radius_major, center_x, center_y + radius_major);
-        try path.curveTo(alloc, center_x - p12_minor, center_y + radius_major, center_x - radius_minor, center_y + p12_major, center_x - radius_minor, center_y);
-        try path.curveTo(alloc, center_x - radius_minor, center_y - p12_major, center_x - p12_minor, center_y - radius_major, center_x, center_y - radius_major);
-        try path.close(alloc);
-        try context.fill(alloc, path);
+        context.resetPath();
+        try context.moveTo(center_x, center_y - radius_major);
+        try context.curveTo(center_x + p12_minor, center_y - radius_major, center_x + radius_minor, center_y - p12_major, center_x + radius_minor, center_y);
+        try context.curveTo(center_x + radius_minor, center_y + p12_major, center_x + p12_minor, center_y + radius_major, center_x, center_y + radius_major);
+        try context.curveTo(center_x - p12_minor, center_y + radius_major, center_x - radius_minor, center_y + p12_major, center_x - radius_minor, center_y);
+        try context.curveTo(center_x - radius_minor, center_y - p12_major, center_x - p12_minor, center_y - radius_major, center_x, center_y - radius_major);
+        try context.close();
+        try context.fill();
     }
 
     return sfc;

--- a/spec/033_fill_zig_mark.zig
+++ b/spec/033_fill_zig_mark.zig
@@ -15,7 +15,7 @@ pub const filename = "033_fill_zig_mark";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 153;
     const height = 140;
-    const sfc = try z2d.Surface.init(.image_surface_rgba, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgba, alloc, width, height);
 
     // <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 153 140">
     // <g fill="#F7A41D">
@@ -39,84 +39,77 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     // </g>
     // </svg>
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xF7, .g = 0xA4, .b = 0x1D } },
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xF7, .g = 0xA4, .b = 0x1D } });
+    context.setAntiAliasingMode(aa_mode);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
-    try path.moveTo(alloc, 46, 22);
-    try path.lineTo(alloc, 28, 44);
-    try path.lineTo(alloc, 19, 30);
-    try path.close(alloc);
-    try path.moveTo(alloc, 46, 22);
-    try path.lineTo(alloc, 33, 33);
-    try path.lineTo(alloc, 28, 44);
-    try path.lineTo(alloc, 22, 44);
-    try path.lineTo(alloc, 22, 95);
-    try path.lineTo(alloc, 31, 95);
-    try path.lineTo(alloc, 20, 100);
-    try path.lineTo(alloc, 12, 117);
-    try path.lineTo(alloc, 0, 117);
-    try path.lineTo(alloc, 0, 22);
-    try path.close(alloc);
-    try path.moveTo(alloc, 31, 95);
-    try path.lineTo(alloc, 12, 117);
-    try path.lineTo(alloc, 4, 106);
-    try path.close(alloc);
+    try context.moveTo(46, 22);
+    try context.lineTo(28, 44);
+    try context.lineTo(19, 30);
+    try context.close();
+    try context.moveTo(46, 22);
+    try context.lineTo(33, 33);
+    try context.lineTo(28, 44);
+    try context.lineTo(22, 44);
+    try context.lineTo(22, 95);
+    try context.lineTo(31, 95);
+    try context.lineTo(20, 100);
+    try context.lineTo(12, 117);
+    try context.lineTo(0, 117);
+    try context.lineTo(0, 22);
+    try context.close();
+    try context.moveTo(31, 95);
+    try context.lineTo(12, 117);
+    try context.lineTo(4, 106);
+    try context.close();
 
-    try path.moveTo(alloc, 56, 22);
-    try path.lineTo(alloc, 62, 36);
-    try path.lineTo(alloc, 37, 44);
-    try path.close(alloc);
-    try path.moveTo(alloc, 56, 22);
-    try path.lineTo(alloc, 111, 22);
-    try path.lineTo(alloc, 111, 44);
-    try path.lineTo(alloc, 37, 44);
-    try path.lineTo(alloc, 56, 32);
-    try path.close(alloc);
-    try path.moveTo(alloc, 116, 95);
-    try path.lineTo(alloc, 97, 117);
-    try path.lineTo(alloc, 90, 104);
-    try path.close(alloc);
-    try path.moveTo(alloc, 116, 95);
-    try path.lineTo(alloc, 100, 104);
-    try path.lineTo(alloc, 97, 117);
-    try path.lineTo(alloc, 42, 117);
-    try path.lineTo(alloc, 42, 95);
-    try path.close(alloc);
-    try path.moveTo(alloc, 150, 0);
-    try path.lineTo(alloc, 52, 117);
-    try path.lineTo(alloc, 3, 140);
-    try path.lineTo(alloc, 101, 22);
-    try path.close(alloc);
+    try context.moveTo(56, 22);
+    try context.lineTo(62, 36);
+    try context.lineTo(37, 44);
+    try context.close();
+    try context.moveTo(56, 22);
+    try context.lineTo(111, 22);
+    try context.lineTo(111, 44);
+    try context.lineTo(37, 44);
+    try context.lineTo(56, 32);
+    try context.close();
+    try context.moveTo(116, 95);
+    try context.lineTo(97, 117);
+    try context.lineTo(90, 104);
+    try context.close();
+    try context.moveTo(116, 95);
+    try context.lineTo(100, 104);
+    try context.lineTo(97, 117);
+    try context.lineTo(42, 117);
+    try context.lineTo(42, 95);
+    try context.close();
+    try context.moveTo(150, 0);
+    try context.lineTo(52, 117);
+    try context.lineTo(3, 140);
+    try context.lineTo(101, 22);
+    try context.close();
 
-    try path.moveTo(alloc, 141, 22);
-    try path.lineTo(alloc, 140, 40);
-    try path.lineTo(alloc, 122, 45);
-    try path.close(alloc);
-    try path.moveTo(alloc, 153, 22);
-    try path.lineTo(alloc, 153, 117);
-    try path.lineTo(alloc, 106, 117);
-    try path.lineTo(alloc, 120, 105);
-    try path.lineTo(alloc, 125, 95);
-    try path.lineTo(alloc, 131, 95);
-    try path.lineTo(alloc, 131, 45);
-    try path.lineTo(alloc, 122, 45);
-    try path.lineTo(alloc, 132, 36);
-    try path.lineTo(alloc, 141, 22);
-    try path.close(alloc);
-    try path.moveTo(alloc, 125, 95);
-    try path.lineTo(alloc, 130, 110);
-    try path.lineTo(alloc, 106, 117);
-    try path.close(alloc);
+    try context.moveTo(141, 22);
+    try context.lineTo(140, 40);
+    try context.lineTo(122, 45);
+    try context.close();
+    try context.moveTo(153, 22);
+    try context.lineTo(153, 117);
+    try context.lineTo(106, 117);
+    try context.lineTo(120, 105);
+    try context.lineTo(125, 95);
+    try context.lineTo(131, 95);
+    try context.lineTo(131, 45);
+    try context.lineTo(122, 45);
+    try context.lineTo(132, 36);
+    try context.lineTo(141, 22);
+    try context.close();
+    try context.moveTo(125, 95);
+    try context.lineTo(130, 110);
+    try context.lineTo(106, 117);
+    try context.close();
 
-    try context.fill(alloc, path);
+    try context.fill();
     return sfc;
 }

--- a/spec/034_stroke_cross.zig
+++ b/spec/034_stroke_cross.zig
@@ -12,36 +12,28 @@ pub const filename = "034_stroke_cross";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 250;
     const height = 250;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-        .line_width = 5,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(5);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
-
-    try path.moveTo(alloc, 100, 50);
-    try path.relLineTo(alloc, 0, 50);
-    try path.relLineTo(alloc, -50, 0);
-    try path.relLineTo(alloc, 0, 50);
-    try path.relLineTo(alloc, 50, 0);
-    try path.relLineTo(alloc, 0, 50);
-    try path.relLineTo(alloc, 50, 0);
-    try path.relLineTo(alloc, 0, -50);
-    try path.relLineTo(alloc, 50, 0);
-    try path.relLineTo(alloc, 0, -50);
-    try path.relLineTo(alloc, -50, 0);
-    try path.relLineTo(alloc, 0, -50);
-    try path.close(alloc);
-    try context.stroke(alloc, path);
+    try context.moveTo(100, 50);
+    try context.relLineTo(0, 50);
+    try context.relLineTo(-50, 0);
+    try context.relLineTo(0, 50);
+    try context.relLineTo(50, 0);
+    try context.relLineTo(0, 50);
+    try context.relLineTo(50, 0);
+    try context.relLineTo(0, -50);
+    try context.relLineTo(50, 0);
+    try context.relLineTo(0, -50);
+    try context.relLineTo(-50, 0);
+    try context.relLineTo(0, -50);
+    try context.close();
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/035_arc_command.zig
+++ b/spec/035_arc_command.zig
@@ -17,53 +17,46 @@ pub const filename = "035_arc_command";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 400;
     const height = 400;
-    const sfc = try z2d.Surface.initPixel(
+    var sfc = try z2d.Surface.initPixel(
         .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White
         alloc,
         width,
         height,
     );
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0x00, .b = 0x00 } }, // Red for our initial draw
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-        .line_width = 5,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0x00, .b = 0x00 } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(5);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
-    try path.moveTo(alloc, 200, 200);
-    try path.arcNegative(alloc, 200, 200, 150, math.pi, math.pi * 1.5);
-    try path.close(alloc);
-    try context.fill(alloc, path);
+    try context.moveTo(200, 200);
+    try context.arcNegative(200, 200, 150, math.pi, math.pi * 1.5);
+    try context.close();
+    try context.fill();
     context.pattern = .{
         .opaque_pattern = .{
             .pixel = .{ .rgb = .{ .r = 0x00, .g = 0x00, .b = 0xFF } }, // Blue for stroke
         },
     };
-    try context.stroke(alloc, path);
+    try context.stroke();
 
-    path.reset();
-    try path.moveTo(alloc, 175, 175);
-    try path.arc(alloc, 175, 175, 150, math.pi, math.pi * 1.5);
-    try path.close(alloc);
+    context.resetPath();
+    try context.moveTo(175, 175);
+    try context.arc(175, 175, 150, math.pi, math.pi * 1.5);
+    try context.close();
     context.pattern = .{
         .opaque_pattern = .{
             .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0x00 } }, // Yellow for fill
         },
     };
-    try context.fill(alloc, path);
+    try context.fill();
     context.pattern = .{
         .opaque_pattern = .{
             .pixel = .{ .rgb = .{ .r = 0x00, .g = 0x00, .b = 0xFF } }, // Blue for stroke
         },
     };
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/036_stroke_colinear.zig
+++ b/spec/036_stroke_colinear.zig
@@ -11,93 +11,85 @@ pub const filename = "036_stroke_colinear";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 100;
     const height = 240;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .line_width = 4,
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(4);
 
     // clockwise
-    try path.moveTo(alloc, 40, 50);
-    try path.lineTo(alloc, 35, 60);
-    try path.lineTo(alloc, 30, 70);
-    try path.lineTo(alloc, 10, 50);
+    try context.moveTo(40, 50);
+    try context.lineTo(35, 60);
+    try context.lineTo(30, 70);
+    try context.lineTo(10, 50);
 
     // counter-clockwise
-    try path.moveTo(alloc, 10, 10);
-    try path.lineTo(alloc, 20, 20);
-    try path.lineTo(alloc, 30, 30);
-    try path.lineTo(alloc, 40, 10);
+    try context.moveTo(10, 10);
+    try context.lineTo(20, 20);
+    try context.lineTo(30, 30);
+    try context.lineTo(40, 10);
 
     // clockwise, closed
-    try path.moveTo(alloc, 90, 50);
-    try path.lineTo(alloc, 85, 60);
-    try path.lineTo(alloc, 80, 70);
-    try path.lineTo(alloc, 60, 50);
-    try path.close(alloc);
+    try context.moveTo(90, 50);
+    try context.lineTo(85, 60);
+    try context.lineTo(80, 70);
+    try context.lineTo(60, 50);
+    try context.close();
 
     // counter-clockwise, closed
-    try path.moveTo(alloc, 60, 10);
-    try path.lineTo(alloc, 70, 20);
-    try path.lineTo(alloc, 80, 30);
-    try path.lineTo(alloc, 90, 10);
-    try path.close(alloc);
+    try context.moveTo(60, 10);
+    try context.lineTo(70, 20);
+    try context.lineTo(80, 30);
+    try context.lineTo(90, 10);
+    try context.close();
 
     // single line, UL -> DR
-    try path.moveTo(alloc, 10, 90);
-    try path.lineTo(alloc, 25, 100);
-    try path.lineTo(alloc, 40, 110);
+    try context.moveTo(10, 90);
+    try context.lineTo(25, 100);
+    try context.lineTo(40, 110);
 
     // single line, DL -> UR
-    try path.moveTo(alloc, 10, 150);
-    try path.lineTo(alloc, 25, 140);
-    try path.lineTo(alloc, 40, 130);
+    try context.moveTo(10, 150);
+    try context.lineTo(25, 140);
+    try context.lineTo(40, 130);
 
     // single line, UR -> DL
-    try path.moveTo(alloc, 90, 90);
-    try path.lineTo(alloc, 75, 100);
-    try path.lineTo(alloc, 60, 110);
+    try context.moveTo(90, 90);
+    try context.lineTo(75, 100);
+    try context.lineTo(60, 110);
 
     // single line, DR -> UL
-    try path.moveTo(alloc, 90, 150);
-    try path.lineTo(alloc, 75, 140);
-    try path.lineTo(alloc, 60, 130);
+    try context.moveTo(90, 150);
+    try context.lineTo(75, 140);
+    try context.lineTo(60, 130);
 
     // switchback
-    try path.moveTo(alloc, 10, 170);
-    try path.lineTo(alloc, 30, 190);
-    try path.lineTo(alloc, 20, 180);
-    try path.lineTo(alloc, 40, 170);
+    try context.moveTo(10, 170);
+    try context.lineTo(30, 190);
+    try context.lineTo(20, 180);
+    try context.lineTo(40, 170);
 
     // switchback, reflected on x-axis
-    try path.moveTo(alloc, 90, 170);
-    try path.lineTo(alloc, 70, 190);
-    try path.lineTo(alloc, 80, 180);
-    try path.lineTo(alloc, 60, 170);
+    try context.moveTo(90, 170);
+    try context.lineTo(70, 190);
+    try context.lineTo(80, 180);
+    try context.lineTo(60, 170);
 
     // clockwise after start
-    try path.moveTo(alloc, 40, 210);
-    try path.lineTo(alloc, 30, 230);
-    try path.lineTo(alloc, 20, 220);
-    try path.lineTo(alloc, 10, 210);
+    try context.moveTo(40, 210);
+    try context.lineTo(30, 230);
+    try context.lineTo(20, 220);
+    try context.lineTo(10, 210);
 
     // counter-clockwise after start
-    try path.moveTo(alloc, 60, 210);
-    try path.lineTo(alloc, 70, 230);
-    try path.lineTo(alloc, 80, 220);
-    try path.lineTo(alloc, 90, 210);
+    try context.moveTo(60, 210);
+    try context.lineTo(70, 230);
+    try context.lineTo(80, 220);
+    try context.lineTo(90, 210);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/037_stroke_join_overlap.zig
+++ b/spec/037_stroke_join_overlap.zig
@@ -12,40 +12,32 @@ pub const filename = "037_stroke_join_overlap";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 200;
     const height = 200;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .line_width = 5,
-        .miter_limit = 4,
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(5);
+    context.setMiterLimit(4);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    try context.moveTo(10, 10);
+    try context.lineTo(50, 90);
+    try context.lineTo(35, 50);
 
-    try path.moveTo(alloc, 10, 10);
-    try path.lineTo(alloc, 50, 90);
-    try path.lineTo(alloc, 35, 50);
+    try context.moveTo(190, 10);
+    try context.lineTo(150, 90);
+    try context.lineTo(165, 50);
 
-    try path.moveTo(alloc, 190, 10);
-    try path.lineTo(alloc, 150, 90);
-    try path.lineTo(alloc, 165, 50);
+    try context.moveTo(10, 190);
+    try context.lineTo(50, 110);
+    try context.lineTo(35, 150);
 
-    try path.moveTo(alloc, 10, 190);
-    try path.lineTo(alloc, 50, 110);
-    try path.lineTo(alloc, 35, 150);
+    try context.moveTo(190, 190);
+    try context.lineTo(150, 110);
+    try context.lineTo(165, 150);
 
-    try path.moveTo(alloc, 190, 190);
-    try path.lineTo(alloc, 150, 110);
-    try path.lineTo(alloc, 165, 150);
-
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/038_stroke_zero_length.zig
+++ b/spec/038_stroke_zero_length.zig
@@ -11,35 +11,27 @@ pub const filename = "038_stroke_zero_length";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 60;
     const height = 60;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .line_width = 10,
-        .line_cap_mode = .round,
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(10);
+    context.setLineCapMode(.round);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    try context.moveTo(10, 10);
+    try context.close();
 
-    try path.moveTo(alloc, 10, 10);
-    try path.close(alloc);
-
-    try path.moveTo(alloc, 30, 30);
-    try path.lineTo(alloc, 30, 30);
-    try path.lineTo(alloc, 30, 30);
-    try path.close(alloc);
+    try context.moveTo(30, 30);
+    try context.lineTo(30, 30);
+    try context.lineTo(30, 30);
+    try context.close();
 
     // This should not draw anything
-    try path.moveTo(alloc, 50, 50);
+    try context.moveTo(50, 50);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/039_stroke_paint_extent_dontclip.zig
+++ b/spec/039_stroke_paint_extent_dontclip.zig
@@ -12,28 +12,20 @@ pub const filename = "039_stroke_paint_extent_dontclip";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 50;
     const height = 80;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .line_width = 5,
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(5);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    try context.moveTo(40, 50);
+    try context.lineTo(35, 60);
+    try context.lineTo(30, 70);
+    try context.lineTo(10, 50);
 
-    try path.moveTo(alloc, 40, 50);
-    try path.lineTo(alloc, 35, 60);
-    try path.lineTo(alloc, 30, 70);
-    try path.lineTo(alloc, 10, 50);
-
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/040_stroke_corner_symmetrical.zig
+++ b/spec/040_stroke_corner_symmetrical.zig
@@ -13,25 +13,17 @@ pub const filename = "040_stroke_corner_symmetrical";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 18;
     const height = 36;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    try context.moveTo(0, 0);
+    try context.lineTo(width, height);
 
-    try path.moveTo(alloc, 0, 0);
-    try path.lineTo(alloc, width, height);
-
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/041_stroke_noop_lineto.zig
+++ b/spec/041_stroke_noop_lineto.zig
@@ -12,27 +12,19 @@ pub const filename = "041_stroke_noop_lineto";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 18;
     const height = 36;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    try context.moveTo(9, 0);
+    try context.lineTo(9, 9);
+    try context.lineTo(0, 18);
+    try context.lineTo(0, 18);
 
-    try path.moveTo(alloc, 9, 0);
-    try path.lineTo(alloc, 9, 9);
-    try path.lineTo(alloc, 0, 18);
-    try path.lineTo(alloc, 0, 18);
-
-    try context.stroke(alloc, path);
+    try context.stroke();
 
     return sfc;
 }

--- a/spec/042_arc_ellipses.zig
+++ b/spec/042_arc_ellipses.zig
@@ -13,80 +13,68 @@ pub const filename = "042_arc_ellipses";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 400;
     const height = 400;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-        .line_width = 5,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(5);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
     // Add a margin of (10, 10) by translation
-    path.transformation = path.transformation.translate(10, 10);
+    context.translate(10, 10);
     // first ellipse at 0, 0 rx = 50, ry=100
-    _ = try ellipse(&path, alloc, 0, 0, 50, 100);
-    try context.fill(alloc, path);
+    _ = try ellipse(&context, 0, 0, 50, 100, true);
+    try context.fill();
 
     // second as the first, but stroked, at 100, 0)
-    _ = try ellipse(&path, alloc, 100, 0, 50, 100);
-    try context.stroke(alloc, path);
+    _ = try ellipse(&context, 100, 0, 50, 100, true);
+    try context.stroke();
 
-    // as the second, but we capture the CTM to test stroke warping (at 200, 0)
-    var saved_ctm = context.transformation;
-    var saved_line_width = context.line_width;
-    context.transformation = try ellipse(&path, alloc, 200, 0, 50, 100);
-    context.line_width = lw: {
+    // as the second, but we don't reset the CTM to test stroke warping (at 200, 0)
+    var saved_ctm = context.getTransformation();
+    var saved_line_width = context.getLineWidth();
+    try ellipse(&context, 200, 0, 50, 100, false);
+    context.setLineWidth(lw: {
         var ux = saved_line_width;
         var uy = saved_line_width;
-        try context.transformation.deviceToUserDistance(&ux, &uy);
+        try context.deviceToUserDistance(&ux, &uy);
         if (ux < uy) {
             break :lw uy;
         }
         break :lw ux;
-    };
-    try context.stroke(alloc, path);
-    context.transformation = saved_ctm;
-    context.line_width = saved_line_width;
+    });
+    try context.stroke();
+    context.setTransformation(saved_ctm);
+    context.setLineWidth(saved_line_width);
 
     // as the third, but first rotate 45 degrees (at 300, 0)
-    const saved_path_ctm = path.transformation;
-    saved_ctm = context.transformation;
-    saved_line_width = context.line_width;
-    path.transformation = path.transformation.rotate(math.pi / 4.0);
-    context.transformation = try ellipse(&path, alloc, 300, 0, 50, 100);
-    context.line_width = lw: {
+    saved_ctm = context.getTransformation();
+    saved_line_width = context.getLineWidth();
+    context.rotate(math.pi / 4.0);
+    try ellipse(&context, 300, 0, 50, 100, false);
+    context.setLineWidth(lw: {
         var ux = saved_line_width;
         var uy = saved_line_width;
-        try context.transformation.deviceToUserDistance(&ux, &uy);
+        try context.deviceToUserDistance(&ux, &uy);
         if (ux < uy) {
             break :lw uy;
         }
         break :lw ux;
-    };
-    try context.stroke(alloc, path);
-    path.transformation = saved_path_ctm;
-    context.transformation = saved_ctm;
-    context.line_width = saved_line_width;
+    });
+    try context.stroke();
+    context.setTransformation(saved_ctm);
+    context.setLineWidth(saved_line_width);
 
     return sfc;
 }
 
-fn ellipse(path: *z2d.Path, alloc: mem.Allocator, x: f64, y: f64, rx: f64, ry: f64) !z2d.Transformation {
-    const saved_ctm = path.transformation;
-    path.reset();
-    path.transformation = path.transformation
-        .translate(x + rx / 2, y + ry / 2)
-        .scale(rx / 2, ry / 2);
-    try path.arc(alloc, 0, 0, 1, 0, 2 * math.pi);
-    const effective_ctm = path.transformation;
-    path.transformation = saved_ctm;
-    try path.close(alloc);
-    return effective_ctm;
+fn ellipse(context: *z2d.Context, x: f64, y: f64, rx: f64, ry: f64, reset_ctm: bool) !void {
+    const saved_ctm = context.getTransformation();
+    context.resetPath();
+    context.translate(x + rx / 2, y + ry / 2);
+    context.scale(rx / 2, ry / 2);
+    try context.arc(0, 0, 1, 0, 2 * math.pi);
+    if (reset_ctm) context.setTransformation(saved_ctm);
+    try context.close();
 }

--- a/spec/043_rect_transforms.zig
+++ b/spec/043_rect_transforms.zig
@@ -12,83 +12,71 @@ pub const filename = "043_rect_transforms";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 400;
     const height = 400;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-        .line_width = 5,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(5);
 
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
     // Add a margin of (10, 10) by translation
-    path.transformation = path.transformation.translate(10, 10);
+    context.translate(10, 10);
     // first at 0, 0 rx = 50, ry=100
-    _ = try rect(&path, alloc, 0, 0, 50, 100);
-    try context.fill(alloc, path);
+    _ = try rect(&context, 0, 0, 50, 100, true);
+    try context.fill();
 
     // second as the first, but stroked, at 100, 0)
-    _ = try rect(&path, alloc, 100, 0, 50, 100);
-    try context.stroke(alloc, path);
+    _ = try rect(&context, 100, 0, 50, 100, true);
+    try context.stroke();
 
     // as the second, but we capture the CTM to test stroke warping (at 200, 0)
-    var saved_ctm = context.transformation;
-    var saved_line_width = context.line_width;
-    context.transformation = try rect(&path, alloc, 200, 0, 50, 100);
-    context.line_width = lw: {
+    var saved_ctm = context.getTransformation();
+    var saved_line_width = context.getLineWidth();
+    try rect(&context, 200, 0, 50, 100, false);
+    context.setLineWidth(lw: {
         var ux = saved_line_width;
         var uy = saved_line_width;
-        try context.transformation.deviceToUserDistance(&ux, &uy);
+        try context.deviceToUserDistance(&ux, &uy);
         if (ux < uy) {
             break :lw uy;
         }
         break :lw ux;
-    };
-    try context.stroke(alloc, path);
-    context.transformation = saved_ctm;
-    context.line_width = saved_line_width;
+    });
+    try context.stroke();
+    context.setTransformation(saved_ctm);
+    context.setLineWidth(saved_line_width);
 
     // // as the third, but first rotate 45 degrees (at 300, 0)
-    const saved_path_ctm = path.transformation;
-    saved_ctm = context.transformation;
-    saved_line_width = context.line_width;
-    path.transformation = path.transformation.rotate(math.pi / 4.0);
-    context.transformation = try rect(&path, alloc, 300, 0, 50, 100);
-    context.line_width = lw: {
+    saved_ctm = context.getTransformation();
+    saved_line_width = context.getLineWidth();
+    context.rotate(math.pi / 4.0);
+    try rect(&context, 300, 0, 50, 100, false);
+    context.setLineWidth(lw: {
         var ux = saved_line_width;
         var uy = saved_line_width;
-        try context.transformation.deviceToUserDistance(&ux, &uy);
+        try context.deviceToUserDistance(&ux, &uy);
         if (ux < uy) {
             break :lw uy;
         }
         break :lw ux;
-    };
-    try context.stroke(alloc, path);
-    path.transformation = saved_path_ctm;
-    context.transformation = saved_ctm;
-    context.line_width = saved_line_width;
+    });
+    try context.stroke();
+    context.setTransformation(saved_ctm);
+    context.setLineWidth(saved_line_width);
 
     return sfc;
 }
 
-fn rect(path: *z2d.Path, alloc: mem.Allocator, x: f64, y: f64, h: f64, w: f64) !z2d.Transformation {
-    const saved_ctm = path.transformation;
-    path.reset();
-    path.transformation = path.transformation
-        .translate(x, y)
-        .scale(h, w);
-    try path.moveTo(alloc, 0, 0);
-    try path.lineTo(alloc, 1, 0);
-    try path.lineTo(alloc, 1, 1);
-    try path.lineTo(alloc, 0, 1);
-    const effective_ctm = path.transformation;
-    path.transformation = saved_ctm;
-    try path.close(alloc);
-    return effective_ctm;
+fn rect(context: *z2d.Context, x: f64, y: f64, h: f64, w: f64, reset_ctm: bool) !void {
+    const saved_ctm = context.getTransformation();
+    context.resetPath();
+    context.translate(x, y);
+    context.scale(h, w);
+    try context.moveTo(0, 0);
+    try context.lineTo(1, 0);
+    try context.lineTo(1, 1);
+    try context.lineTo(0, 1);
+    if (reset_ctm) context.setTransformation(saved_ctm);
+    try context.close();
 }

--- a/spec/044_line_transforms.zig
+++ b/spec/044_line_transforms.zig
@@ -20,39 +20,36 @@ pub const filename = "044_line_transforms";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 700;
     const height = 400;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-        .line_width = 10,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(10);
 
-    for (0..7) |i| try line(alloc, &context, @floatFromInt(i), false, false);
-    for (0..7) |i| try line(alloc, &context, @floatFromInt(i), true, false);
-    for (0..7) |i| try line(alloc, &context, @floatFromInt(i), false, true);
-    for (0..7) |i| try line(alloc, &context, @floatFromInt(i), true, true);
+    for (0..7) |i| try line(&context, @floatFromInt(i), false, false);
+    for (0..7) |i| try line(&context, @floatFromInt(i), true, false);
+    for (0..7) |i| try line(&context, @floatFromInt(i), false, true);
+    for (0..7) |i| try line(&context, @floatFromInt(i), true, true);
 
     return sfc;
 }
 
-fn line(alloc: mem.Allocator, context: *z2d.Context, i: f64, reverse: bool, round: bool) !void {
-    const saved_context_ctm = context.transformation;
-    defer context.transformation = saved_context_ctm;
+fn line(context: *z2d.Context, i: f64, reverse: bool, round: bool) !void {
+    defer context.resetPath();
 
-    const saved_line_width = context.line_width;
-    defer context.line_width = saved_line_width;
+    const saved_ctm = context.getTransformation();
+    defer context.setTransformation(saved_ctm);
 
-    const saved_pattern = context.pattern;
-    defer context.pattern = saved_pattern;
+    const saved_line_width = context.getLineWidth();
+    defer context.setLineWidth(saved_line_width);
 
-    context.line_cap_mode = if (round) .round else .square;
-    defer context.line_cap_mode = .butt;
+    const saved_source = context.getSource();
+    defer context.setSource(saved_source);
+
+    context.setLineCapMode(if (round) .round else .square);
+    defer context.setLineCapMode(.butt);
 
     const y_offset = yoff: {
         var y: f64 = 50;
@@ -61,40 +58,36 @@ fn line(alloc: mem.Allocator, context: *z2d.Context, i: f64, reverse: bool, roun
         break :yoff y;
     };
 
-    context.transformation = if (reverse)
-        context.transformation
-            .translate(i * 100 + 25, y_offset + 25 * @sin(math.pi / 6.0 * i))
-            .rotate(-math.pi / 6.0 * i)
-            .scale(2, 1)
-    else
-        context.transformation
-            .translate(i * 100 + 25, y_offset - 25 * @sin(math.pi / 6.0 * i))
-            .rotate(math.pi / 6.0 * i)
-            .scale(2, 1);
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
-    path.transformation = context.transformation;
     if (reverse) {
-        try path.moveTo(alloc, 0, 0);
-        try path.lineTo(alloc, 25, 0);
+        context.translate(i * 100 + 25, y_offset + 25 * @sin(math.pi / 6.0 * i));
+        context.rotate(-math.pi / 6.0 * i);
+        context.scale(2, 1);
     } else {
-        try path.moveTo(alloc, 25, 0);
-        try path.lineTo(alloc, 0, 0);
+        context.translate(i * 100 + 25, y_offset - 25 * @sin(math.pi / 6.0 * i));
+        context.rotate(math.pi / 6.0 * i);
+        context.scale(2, 1);
     }
-    context.line_width = lw: {
+    if (reverse) {
+        try context.moveTo(0, 0);
+        try context.lineTo(25, 0);
+    } else {
+        try context.moveTo(25, 0);
+        try context.lineTo(0, 0);
+    }
+    context.setLineWidth(lw: {
         var ux = saved_line_width;
         var uy = saved_line_width;
-        try context.transformation.deviceToUserDistance(&ux, &uy);
+        try context.deviceToUserDistance(&ux, &uy);
         if (ux < uy) {
             break :lw uy;
         }
         break :lw ux;
-    };
-    try context.stroke(alloc, path);
+    });
+    try context.stroke();
 
     // Draw a hairline in red to help validate/measure
-    context.pattern.opaque_pattern.pixel = .{ .rgb = .{ .r = 0xF3, .g = 0x00, .b = 0x00 } }; // Red
-    context.line_width = 1;
+    context.setSource(.{ .rgb = .{ .r = 0xF3, .g = 0x00, .b = 0x00 } });
+    context.setLineWidth(1);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 }

--- a/spec/045_round_join_transforms.zig
+++ b/spec/045_round_join_transforms.zig
@@ -17,63 +17,56 @@ pub const filename = "045_round_join_transforms";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 800;
     const height = 600;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-        .line_width = 20,
-        .line_cap_mode = .round,
-        .line_join_mode = .round,
-    };
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } });
+    context.setAntiAliasingMode(aa_mode);
+    context.setLineWidth(20);
+    context.setLineCapMode(.round);
+    context.setLineJoinMode(.round);
 
-    for (0..12) |i| try line(alloc, &context, @floatFromInt(i));
+    for (0..12) |i| try line(&context, @floatFromInt(i));
 
     return sfc;
 }
 
-fn line(alloc: mem.Allocator, context: *z2d.Context, i: f64) !void {
-    const saved_context_ctm = context.transformation;
-    defer context.transformation = saved_context_ctm;
+fn line(context: *z2d.Context, i: f64) !void {
+    defer context.resetPath();
 
-    const saved_line_width = context.line_width;
-    defer context.line_width = saved_line_width;
+    const saved_ctm = context.getTransformation();
+    defer context.setTransformation(saved_ctm);
 
-    const saved_pattern = context.pattern;
-    defer context.pattern = saved_pattern;
+    const saved_line_width = context.getLineWidth();
+    defer context.setLineWidth(saved_line_width);
+
+    const saved_source = context.getSource();
+    defer context.setSource(saved_source);
 
     const x_offset: f64 = 200 * @mod(i, 4.0) + 100 - 50 * @cos(math.pi / 6.0 * i);
     const y_offset: f64 = 200 * @floor(i / 4.0) + 75 - 37.5 * @sin(math.pi / 6.0 * i);
 
-    context.transformation = context.transformation
-        .translate(x_offset, y_offset)
-        .rotate(math.pi / 6.0 * i)
-        .scale(2, 1);
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
-    path.transformation = context.transformation;
-    try path.moveTo(alloc, 0, 0);
-    try path.lineTo(alloc, 25, 75);
-    try path.lineTo(alloc, 50, 0);
-    context.line_width = lw: {
+    context.translate(x_offset, y_offset);
+    context.rotate(math.pi / 6.0 * i);
+    context.scale(2, 1);
+    try context.moveTo(0, 0);
+    try context.lineTo(25, 75);
+    try context.lineTo(50, 0);
+    context.setLineWidth(lw: {
         var ux = saved_line_width;
         var uy = saved_line_width;
-        try context.transformation.deviceToUserDistance(&ux, &uy);
+        try context.deviceToUserDistance(&ux, &uy);
         if (ux < uy) {
             break :lw uy;
         }
         break :lw ux;
-    };
-    try context.stroke(alloc, path);
+    });
+    try context.stroke();
 
     // Draw a hairline in red to help validate/measure
-    context.pattern.opaque_pattern.pixel = .{ .rgb = .{ .r = 0xF3, .g = 0x00, .b = 0x00 } }; // Red
-    context.line_width = 1;
+    context.setSource(.{ .rgb = .{ .r = 0xF3, .g = 0x00, .b = 0x00 } });
+    context.setLineWidth(1);
 
-    try context.stroke(alloc, path);
+    try context.stroke();
 }

--- a/spec/046_fill_triangle_alpha.zig
+++ b/spec/046_fill_triangle_alpha.zig
@@ -14,33 +14,25 @@ pub const filename = "046_fill_triangle_alpha";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.initPixel(
+    var sfc = try z2d.Surface.initPixel(
         .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White so that srcOver shows up correctly
         alloc,
         width,
         height,
     );
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .alpha8 = .{ .a = 255 } },
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .alpha8 = .{ .a = 255 } });
+    context.setAntiAliasingMode(aa_mode);
 
     const margin = 10;
-    try path.moveTo(alloc, 0 + margin, 0 + margin);
-    try path.lineTo(alloc, width - margin - 1, 0 + margin);
-    try path.lineTo(alloc, width / 2 - 1, height - margin - 1);
-    try path.close(alloc);
+    try context.moveTo(0 + margin, 0 + margin);
+    try context.lineTo(width - margin - 1, 0 + margin);
+    try context.lineTo(width / 2 - 1, height - margin - 1);
+    try context.close();
 
-    try context.fill(alloc, path);
+    try context.fill();
 
     return sfc;
 }

--- a/spec/047_fill_triangle_alpha_gray.zig
+++ b/spec/047_fill_triangle_alpha_gray.zig
@@ -15,33 +15,25 @@ pub const filename = "047_fill_triangle_alpha_gray";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.initPixel(
+    var sfc = try z2d.Surface.initPixel(
         .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White so that srcOver shows up correctly
         alloc,
         width,
         height,
     );
 
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .alpha8 = .{ .a = 127 } },
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
-
-    var path = try z2d.Path.initCapacity(alloc, 0);
-    defer path.deinit(alloc);
+    var context = try z2d.Context.init(alloc, &sfc);
+    defer context.deinit();
+    context.setSource(.{ .alpha8 = .{ .a = 127 } });
+    context.setAntiAliasingMode(aa_mode);
 
     const margin = 10;
-    try path.moveTo(alloc, 0 + margin, 0 + margin);
-    try path.lineTo(alloc, width - margin - 1, 0 + margin);
-    try path.lineTo(alloc, width / 2 - 1, height - margin - 1);
-    try path.close(alloc);
+    try context.moveTo(0 + margin, 0 + margin);
+    try context.lineTo(width - margin - 1, 0 + margin);
+    try context.lineTo(width / 2 - 1, height - margin - 1);
+    try context.close();
 
-    try context.fill(alloc, path);
+    try context.fill();
 
     return sfc;
 }

--- a/spec/048_fill_triangle_static.zig
+++ b/spec/048_fill_triangle_static.zig
@@ -3,6 +3,9 @@
 
 //! Case: Renders and fills a triangle on a 300x300 surface, using a
 //! statically-allocated path buffer.
+//!
+//! This also demonstrates the use of the unmanaged functions in the painter,
+//! completely avoiding the use fo a Context.
 const mem = @import("std").mem;
 
 const z2d = @import("z2d");
@@ -12,17 +15,7 @@ pub const filename = "048_fill_triangle_static";
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     const width = 300;
     const height = 300;
-    const sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
-
-    var context: z2d.Context = .{
-        .surface = sfc,
-        .pattern = .{
-            .opaque_pattern = .{
-                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
-            },
-        },
-        .anti_aliasing_mode = aa_mode,
-    };
+    var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
 
     var path: z2d.StaticPath(5) = .{};
     path.init();
@@ -33,7 +26,17 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     path.lineTo(width / 2 - 1, height - margin - 1);
     path.close();
 
-    try context.fill(alloc, path.wrapped_path);
+    try z2d.painter.fill(
+        alloc,
+        &sfc,
+        &.{
+            .opaque_pattern = .{
+                .pixel = .{ .rgb = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF } }, // White on black
+            },
+        },
+        &path.nodes,
+        .{ .anti_aliasing_mode = aa_mode },
+    );
 
     return sfc;
 }

--- a/src/Context.zig
+++ b/src/Context.zig
@@ -1,8 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 //   Copyright © 2024 Chris Marchesi
 
-//! Context is the draw context, which connects patterns to surfaces, holds
-//! other state data, and is used to dispatch drawing operations.
+//! `Context` represents the managed drawing interface to z2d. It holds a
+//! `Path`, `Surface`, and `Pattern` that it uses for these operations and a
+//! frontend for controlling various options for filling and stroking.
+//!
+//! Every field within the context is controllable via setters or other
+//! frontend methods. It is recommended you do not manipulate the fields within
+//! a context directly. If you do wish further control over the process than
+//! what the context provides, you can use each underlying component in an
+//! unmanaged fashion by following the patterns the context uses as an example.
 const Context = @This();
 
 const mem = @import("std").mem;
@@ -11,36 +18,123 @@ const options = @import("options.zig");
 const painter = @import("painter.zig");
 
 const Path = @import("Path.zig");
+const Pixel = @import("pixel.zig").Pixel;
 const Pattern = @import("pattern.zig").Pattern;
 const Surface = @import("surface.zig").Surface;
 const Transformation = @import("Transformation.zig");
 const PathError = @import("errors.zig").PathError;
 
-/// The underlying surface.
-surface: Surface,
-
-/// The underlying pattern.
-///
-/// The default pattern is RGBA opaque black.
+alloc: mem.Allocator,
+path: Path,
+surface: *Surface,
 pattern: Pattern = .{
     .opaque_pattern = .{
         .pixel = .{ .rgba = .{ .r = 0x00, .g = 0x00, .b = 0x00, .a = 0xFF } },
     },
 },
 
-/// The current line width for drawing operations, in pixels. This value is
-/// taken at call time during `stroke` operations, and has no effect during path
-/// construction.
-line_width: f64 = 2.0,
-
-/// The current fill rule. Note that `stroke` operations always fill non-zero,
-/// regardless of this setting.
+anti_aliasing_mode: options.AntiAliasMode = .default,
 fill_rule: options.FillRule = .non_zero,
-
-/// The current line join style for `stroke` operations.
+line_cap_mode: options.CapMode = .butt,
 line_join_mode: options.JoinMode = .miter,
+line_width: f64 = 2.0,
+miter_limit: f64 = 10.0,
+tolerance: f64 = options.default_tolerance,
+transformation: Transformation = Transformation.identity,
 
-/// The limit when `line_join_mode` is set to `.miter`; in this mode, this
+/// Initializes a `Context` with the passed in allocator and surface. Call deinit
+/// to release the `Path` that is managed by the context.
+pub fn init(alloc: mem.Allocator, surface: *Surface) !Context {
+    return .{
+        .alloc = alloc,
+        .surface = surface,
+        .path = try Path.initCapacity(alloc, 0),
+    };
+}
+
+/// Releases all resources associated with this particular context, such as the
+/// managed `Path`.
+pub fn deinit(self: *Context) void {
+    self.path.deinit(self.alloc);
+    self.path = undefined;
+}
+
+/// Returns the current underlying pixel for the context's pattern.
+pub fn getSource(self: *Context) Pixel {
+    return switch (self.pattern) {
+        .opaque_pattern => |p| p.pixel,
+    };
+}
+
+/// Sets the context's pattern to the supplied `Pixel`. Fill and stroke
+/// operations will draw with this pixel when they are called.
+///
+/// The default pattern is RGBA opaque black.
+pub fn setSource(self: *Context, px: Pixel) void {
+    self.pattern = .{ .opaque_pattern = .{ .pixel = px } };
+}
+
+/// Returns the current anti-aliasing mode.
+pub fn getAntiAliasingMode(self: *Context) options.AntiAliasMode {
+    return self.anti_aliasing_mode;
+}
+
+/// Sets the anti-aliasing mode for fill and stroke operations. The default is
+/// to use anti-aliasing. For how each mode works, see the option's enum
+/// documentation.
+pub fn setAntiAliasingMode(self: *Context, anti_aliasing_mode: options.AntiAliasMode) void {
+    self.anti_aliasing_mode = anti_aliasing_mode;
+}
+
+/// Returns the current fill rule for the context.
+pub fn getFillRule(self: *Context) options.FillRule {
+    return self.fill_rule;
+}
+
+/// Sets how edges are counted during fill operations. The default mode is
+/// .non_zero.
+pub fn setFillRule(self: *Context, fill_rule: options.FillRule) void {
+    self.fill_rule = fill_rule;
+}
+
+/// Returns the current line cap mode for the context.
+pub fn getLineCapMode(self: *Context) options.CapMode {
+    return self.line_cap_mode;
+}
+
+/// Sets how the ends of lines are drawn during stroke operations, a process
+/// known as "capping". The default cap mode is .butt.
+pub fn setLineCapMode(self: *Context, line_cap_mode: options.CapMode) void {
+    self.line_cap_mode = line_cap_mode;
+}
+
+/// Returns the current line join mode for the context.
+pub fn getLineJoinMode(self: *Context) options.JoinMode {
+    return self.line_join_mode;
+}
+
+/// Sets how lines are joined during stroke operations.
+pub fn setLineJoinMode(self: *Context, line_join_mode: options.JoinMode) void {
+    self.line_join_mode = line_join_mode;
+}
+
+/// Returns the current line width for the context.
+pub fn getLineWidth(self: *Context) f64 {
+    return self.line_width;
+}
+
+/// Sets the line width for stroking operations, in pixels. This value is taken
+/// at call time of `stroke`, and has no effect during path construction.
+pub fn setLineWidth(self: *Context, line_width: f64) void {
+    self.line_width = line_width;
+}
+
+/// Returns the current miter limit for the context.
+pub fn getMiterLimit(self: *Context) f64 {
+    return self.miter_limit;
+}
+
+/// Sets the limit when `line_join_mode` is set to `.miter`; in this mode, this
 /// value determines when the join is instead drawn as a bevel. This can be
 /// used to prevent extremely large miter points that result from very sharp
 /// angled joins.
@@ -50,19 +144,19 @@ line_join_mode: options.JoinMode = .miter,
 /// line width. This is also described by 1 / sin(Θ / 2), where Θ is the
 /// interior angle.
 ///
-/// The default limit is 10.0, which sets the cutoff at ~11 degrees. A
-/// miter limit of 2.0 translates to ~60 degrees, and a limit of 1.414
-/// translates to ~90 degrees.
-miter_limit: f64 = 10.0,
+/// The default limit is 10.0, which sets the cutoff at ~11 degrees. A miter
+/// limit of 2.0 translates to ~60 degrees, and a limit of 1.414 translates to
+/// ~90 degrees.
+pub fn setMiterLimit(self: *Context, miter_limit: f64) void {
+    self.miter_limit = miter_limit;
+}
 
-/// The current line cap rule for `stroke` operations.
-line_cap_mode: options.CapMode = .butt,
+/// Returns the current error tolerance for the context.
+pub fn getTolerance(self: *Context) f64 {
+    return self.tolerance;
+}
 
-/// The current anti-aliasing mode. The default is the aptly-named
-/// "default" anti-aliasing mode.
-anti_aliasing_mode: options.AntiAliasMode = .default,
-
-/// The maximum error tolerance used for approximating curves and arcs. A
+/// Sets the maximum error tolerance used for approximating curves and arcs. A
 /// higher tolerance will give better performance, but "blockier" curves. The
 /// default tolerance is 0.1, and values below this are unlikely to give better
 /// visual results. This value has a minimum of 0.001, values below this are
@@ -72,30 +166,214 @@ anti_aliasing_mode: options.AntiAliasMode = .default,
 /// caps and joins, which use static vertices for plotting. This can produce
 /// marked artifacts at relatively low tolerance settings, so take care when
 /// changing under these scenarios.
-tolerance: f64 = options.default_tolerance,
+pub fn setTolerance(self: *Context, tolerance: f64) void {
+    self.tolerance = tolerance;
+    self.path.tolerance = tolerance;
+}
 
-/// The current transformation matrix (CTM) for this path.
+/// Returns the current transformation matrix (CTM) for the context.
+pub fn getTransformation(self: *Context) Transformation {
+    return self.transformation;
+}
+
+/// Modifies the current transformation matrix (CTM) by setting it equal to the
+/// supplied matrix.
+pub fn setTransformation(self: *Context, transformation: Transformation) void {
+    self.transformation = transformation;
+    self.path.transformation = transformation;
+}
+
+/// Modifies the current transformation matrix (CTM) to the identity matrix
+/// (i.e., no transformation takes place).
+pub fn setIdentity(self: *Context) void {
+    self.setTransformation(Transformation.identity);
+}
+
+/// Modifies the current transformation matrix (CTM) by multiplying it with the
+/// supplied matrix.
+pub fn mul(self: *Context, a: Transformation) void {
+    self.setTransformation(self.getTransformation().mul(a));
+}
+
+/// Modifies the current transformation matrix (CTM) by applying a co-ordinate
+/// offset to the origin.
+pub fn translate(self: *Context, tx: f64, ty: f64) void {
+    self.setTransformation(self.getTransformation().translate(tx, ty));
+}
+
+/// Modifies the current transformation matrix (CTM) by rotating around the
+/// origin by `angle` (in radians).
+pub fn rotate(self: *Context, angle: f64) void {
+    self.setTransformation(self.getTransformation().rotate(angle));
+}
+
+/// Modifies the current transformation matrix (CTM) by scaling by `(sx, sy)`.
+/// When `sx` and `sy` are not equal, a stretching effect will be achieved.
+pub fn scale(self: *Context, sx: f64, sy: f64) void {
+    self.setTransformation(self.getTransformation().scale(sx, sy));
+}
+
+/// Applies the current transformation matrix (CTM) to the supplied `x` and `y`.
+pub fn userToDevice(self: *Context, x: *f64, y: *f64) void {
+    self.transformation.userToDevice(x, y);
+}
+
+/// Applies the current transformation matrix (CTM) to the supplied `x` and
+/// `y`, but ignores translation.
+pub fn userToDeviceDistance(self: *Context, x: *f64, y: *f64) void {
+    self.transformation.userToDeviceDistance(x, y);
+}
+
+/// Applies the inverse of the current transformation matrix (CTM) to the
+/// supplied `x` and `y`.
+pub fn deviceToUser(self: *Context, x: *f64, y: *f64) !void {
+    try self.transformation.deviceToUser(x, y);
+}
+
+/// Applies the inverse of the current transformation matrix (CTM) to the
+/// supplied `x` and `y`, but ignores translation.
+pub fn deviceToUserDistance(self: *Context, x: *f64, y: *f64) !void {
+    try self.transformation.deviceToUserDistance(x, y);
+}
+
+/// Rests the path set, clearing all nodes and state.
+pub fn resetPath(self: *Context) void {
+    self.path.reset();
+}
+
+/// Starts a new path, and moves the current point to it.
+pub fn moveTo(self: *Context, x: f64, y: f64) !void {
+    try self.path.moveTo(self.alloc, x, y);
+}
+
+/// Begins a new sub-path relative to the current point. Calling this
+/// without a current point triggers safety-checked undefined behavior.
+pub fn relMoveTo(self: *Context, x: f64, y: f64) void {
+    try self.path.relMoveTo(self.alloc, x, y);
+}
+
+/// Draws a line from the current point to the specified point and sets
+/// it as the current point. Acts as a `moveTo` instead if there is no
+/// current point.
+pub fn lineTo(self: *Context, x: f64, y: f64) !void {
+    try self.path.lineTo(self.alloc, x, y);
+}
+
+/// Draws a line relative to the current point. Calling this without a
+/// current point triggers safety-checked undefined behavior.
+pub fn relLineTo(self: *Context, x: f64, y: f64) !void {
+    try self.path.relLineTo(self.alloc, x, y);
+}
+
+/// Draws a cubic bezier with the three supplied control points from
+/// the current point. The new current point is set to (x3, y3).
+/// Calling this without a current point triggers safety-checked
+/// undefined behavior.
+pub fn curveTo(
+    self: *Context,
+    x1: f64,
+    y1: f64,
+    x2: f64,
+    y2: f64,
+    x3: f64,
+    y3: f64,
+) !void {
+    try self.path.curveTo(self.alloc, x1, y1, x2, y2, x3, y3);
+}
+
+/// Draws a cubic bezier relative to the current point. Calling this
+/// without a current point triggers safety-checked undefined behavior.
+pub fn relCurveTo(
+    self: *Context,
+    x1: f64,
+    y1: f64,
+    x2: f64,
+    y2: f64,
+    x3: f64,
+    y3: f64,
+) !void {
+    try self.path.relCurveTo(self.alloc, x1, y1, x2, y2, x3, y3);
+}
+
+/// Adds a circular arc of the given radius to the current path. The arc is
+/// centered at (xc, yc), begins at angle1 and proceeds in the direction of
+/// increasing angles (i.e., counterclockwise direction) to end at angle2.
 ///
-/// The transformation matrix in a context is separate from the CTM in any
-/// given `Path`. It has more subtle influences on drawing: in stroking, it
-/// influences line width respective to scale, warping due to a warped scale
-/// (e.g., different x and y scale), and any respective capping. In filling, it
-/// is (currently) ignored.
+/// If angle2 is less than angle1, it will be increased by 2 * Π until it's
+/// greater than angle1.
 ///
-/// Synchronization of CTM between here and `Path`, if desired, is currently an
-/// exercise left to the consumer.
-transformation: Transformation = Transformation.identity,
+/// Angles are measured at radians (to convert from degrees, multiply by Π /
+/// 180).
+///
+/// If there's a current point, an initial line segment will be added to the
+/// path to connect the current point to the beginning of the arc. If this
+/// behavior is undesired, call `resetPath` before calling. This will trigger a
+/// `moveTo` before the splines are plotted, creating a new subpath.
+///
+/// After this operation, the current point will be the end of the arc.
+///
+/// ## Drawing an ellipse
+///
+/// In order to draw an ellipse, use `arc` along with a transformation. The
+/// following example will draw an elliptical arc at `(x, y)` bounded by the
+/// rectangle of `width` by `height` (i.e., the rectangle controls the lengths
+/// of the radii).
+///
+/// ```
+/// const saved_ctm = context.getTransformation();
+/// context.translate(x + width / 2, y + height / 2);
+/// context.scale(width / 2, height / 2);
+/// try context.arc(0, 0, 1, 0, 2 + math.pi);
+/// context.setTransformation(saved_ctm);
+/// ```
+///
+pub fn arc(
+    self: *Context,
+    xc: f64,
+    yc: f64,
+    radius: f64,
+    angle1: f64,
+    angle2: f64,
+) !void {
+    try self.path.arc(self.alloc, xc, yc, radius, angle1, angle2);
+}
+
+/// Like arc, but draws in the reverse direction, i.e., begins at angle1, and
+/// moves in decreasing angles (i.e., counterclockwise direction) to end at
+/// angle2. If angle2 is greater than angle1, it will be decreased by 2 * Π
+/// until it's less than angle1.
+pub fn arcNegative(
+    self: *Context,
+    xc: f64,
+    yc: f64,
+    radius: f64,
+    angle1: f64,
+    angle2: f64,
+) !void {
+    try self.path.arcNegative(self.alloc, xc, yc, radius, angle1, angle2);
+}
+
+/// Closes the path by drawing a line from the current point by the
+/// starting point. No effect if there is no current point.
+pub fn close(self: *Context) !void {
+    try self.path.close(self.alloc);
+}
+
+/// Returns true if all subpaths in the path set are currently closed.
+pub fn isPathClosed(self: *Context) bool {
+    return self.path.isClosed();
+}
 
 /// Runs a fill operation on the path(s) in the supplied set. All paths in the
 /// set must be closed.
 ///
 /// This is a no-op if there are no nodes.
-pub fn fill(self: *Context, alloc: mem.Allocator, path: Path) !void {
+pub fn fill(self: *Context) !void {
     try painter.fill(
-        alloc,
-        &self.surface,
+        self.alloc,
+        self.surface,
         &self.pattern,
-        path.nodes.items,
+        self.path.nodes.items,
         .{
             .anti_aliasing_mode = self.anti_aliasing_mode,
             .fill_rule = self.fill_rule,
@@ -115,12 +393,12 @@ pub fn fill(self: *Context, alloc: mem.Allocator, path: Path) !void {
 /// `line_join_mode` (see `options.JoinMode`).
 ///
 /// This is a no-op if there are no nodes.
-pub fn stroke(self: *Context, alloc: mem.Allocator, path: Path) !void {
+pub fn stroke(self: *Context) !void {
     try painter.stroke(
-        alloc,
-        &self.surface,
+        self.alloc,
+        self.surface,
         &self.pattern,
-        path.nodes.items,
+        self.path.nodes.items,
         .{
             .anti_aliasing_mode = self.anti_aliasing_mode,
             .line_cap_mode = self.line_cap_mode,

--- a/src/Path.zig
+++ b/src/Path.zig
@@ -281,7 +281,7 @@ pub fn relCurveToAssumeCapacity(
 /// path.transformation = path.transformation
 ///     .translate(x + width / 2, y + height / 2);
 ///     .scale(width / 2, height / 2);
-/// try path.arc(alloc, 0, 0, 1, 0, 2 + math.pi, false, null);
+/// try path.arc(alloc, 0, 0, 1, 0, 2 + math.pi);
 /// path.transformation = saved_ctm;
 /// ```
 ///

--- a/src/painter.zig
+++ b/src/painter.zig
@@ -42,7 +42,7 @@ pub const FillOpts = struct {
 pub fn fill(
     alloc: mem.Allocator,
     surface: *Surface,
-    pattern: *Pattern,
+    pattern: *const Pattern,
     nodes: []const PathNode,
     opts: FillOpts,
 ) !void {
@@ -111,7 +111,7 @@ pub const StrokeOpts = struct {
 pub fn stroke(
     alloc: mem.Allocator,
     surface: *Surface,
-    pattern: *Pattern,
+    pattern: *const Pattern,
     nodes: []const PathNode,
     opts: StrokeOpts,
 ) !void {
@@ -169,7 +169,7 @@ pub fn stroke(
 fn paintDirect(
     alloc: mem.Allocator,
     surface: *Surface,
-    pattern: *Pattern,
+    pattern: *const Pattern,
     polygons: PolygonList,
     fill_rule: FillRule,
 ) !void {
@@ -222,7 +222,7 @@ fn paintDirect(
 fn paintComposite(
     alloc: mem.Allocator,
     surface: *Surface,
-    pattern: *Pattern,
+    pattern: *const Pattern,
     polygons: PolygonList,
     fill_rule: FillRule,
     scale: f64,

--- a/src/z2d.zig
+++ b/src/z2d.zig
@@ -56,6 +56,7 @@
 
 pub const surface = @import("surface.zig");
 pub const pattern = @import("pattern.zig");
+pub const painter = @import("painter.zig");
 pub const pixel = @import("pixel.zig");
 pub const options = @import("options.zig");
 pub const png_exporter = @import("export_png.zig");


### PR DESCRIPTION
This commit is the final piece of the current API overhaul - the managed `Context`.

This is now the place where all managed drawing operations are expected to take place. It pulls together all of our umnanaged components - surfaces, patterns, paths, and painter operations, and provides a managed frontend to these operations, doing things such as holding an allocator for said unmanaged operations (that need one), and providing synchronization of settings such as transformation matrices and tolerance.

Helpers have been added to get and set every setting within the context; it's now considered unsupported behavior for a consumer to set a field directly on a context (or need to set one directly, for that matter, which should help steer further updates).

If someone requires functionality that the `Context` is incapable of providing or would be considered unsuitable for the context, the recommendation is to now use the individual components in an unmanaged way. For this, the `Context` serves as an example for how this can be done.