### PR TITLE
Add Tracy profiler support into acceptance tests

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,6 +3,12 @@
 .{
     .name = "z2d",
     .version = "0.1.0",
+    .dependencies = .{
+        .@"zig-tracy" = .{
+            .url = "git+https://github.com/vancluever/zig-tracy?ref=fix-callstack#6e123ee26032e49a1a0039524ddf7970692931d9",
+            .hash = "122094fc39764bd527269d3721f52fc3b8cbb72bc4cdbd3345cbc2cd941936f3d185",
+        },
+    },
     .paths = .{
         "build.zig",
         "build.zig.zon",


### PR DESCRIPTION
This adds Tracy profiler support into the acceptance tests.

We will likely keep Tracy out of the main library just to ensure it's not polluted by profiler code, unless people ask for it, and/or if pluggable profiler support gets added to Zig itself.