### PR TITLE
internal: move all ArrayLists to be unmanaged

### DIFF
--- a/src/internal/FillPlotter.zig
+++ b/src/internal/FillPlotter.zig
@@ -125,24 +125,24 @@ const SplinePlotterCtx = struct {
 
 test "degenerate line_to" {
     const alloc = testing.allocator;
-    var nodes = std.ArrayList(nodepkg.PathNode).init(alloc);
-    defer nodes.deinit();
-    try nodes.append(.{ .move_to = .{ .point = .{ .x = 5, .y = 0 } } });
-    try nodes.append(.{ .line_to = .{ .point = .{ .x = 10, .y = 10 } } });
-    try nodes.append(.{ .line_to = .{ .point = .{ .x = 10, .y = 10 } } });
-    try nodes.append(.{ .line_to = .{ .point = .{ .x = 0, .y = 10 } } });
-    try nodes.append(.{ .close_path = .{} });
-    try nodes.append(.{ .move_to = .{ .point = .{ .x = 5, .y = 0 } } });
+    var nodes: std.ArrayListUnmanaged(nodepkg.PathNode) = .{};
+    defer nodes.deinit(alloc);
+    try nodes.append(alloc, .{ .move_to = .{ .point = .{ .x = 5, .y = 0 } } });
+    try nodes.append(alloc, .{ .line_to = .{ .point = .{ .x = 10, .y = 10 } } });
+    try nodes.append(alloc, .{ .line_to = .{ .point = .{ .x = 10, .y = 10 } } });
+    try nodes.append(alloc, .{ .line_to = .{ .point = .{ .x = 0, .y = 10 } } });
+    try nodes.append(alloc, .{ .close_path = .{} });
+    try nodes.append(alloc, .{ .move_to = .{ .point = .{ .x = 5, .y = 0 } } });
 
     var result = try plot(alloc, nodes.items, 1, 0.1);
     defer result.deinit(alloc);
     try testing.expectEqual(1, result.polygons.len());
     var corners_len: usize = 0;
-    var corners = std.ArrayList(Point).init(alloc);
-    defer corners.deinit();
+    var corners: std.ArrayListUnmanaged(Point) = .{};
+    defer corners.deinit(alloc);
     var next_: ?*Polygon.CornerList.Node = result.polygons.first.?.findLast().data.corners.first;
     while (next_) |n| {
-        try corners.append(n.data);
+        try corners.append(alloc, n.data);
         corners_len += 1;
         next_ = n.next;
     }

--- a/src/internal/StrokePlotter.zig
+++ b/src/internal/StrokePlotter.zig
@@ -56,8 +56,8 @@ pub fn init(
     };
 }
 
-pub fn deinit(self: *StrokePlotter) void {
-    self.pen.deinit();
+pub fn deinit(self: *StrokePlotter, alloc: mem.Allocator) void {
+    self.pen.deinit(alloc);
 }
 
 pub fn plot(
@@ -680,11 +680,11 @@ test "assert ok: degenerate moveto -> lineto, then good lineto" {
     {
         // p0 -> p1 is equal
         const alloc = testing.allocator;
-        var nodes = std.ArrayList(nodepkg.PathNode).init(alloc);
-        defer nodes.deinit();
-        try nodes.append(.{ .move_to = .{ .point = .{ .x = 10, .y = 10 } } });
-        try nodes.append(.{ .line_to = .{ .point = .{ .x = 10, .y = 10 } } });
-        try nodes.append(.{ .line_to = .{ .point = .{ .x = 20, .y = 20 } } });
+        var nodes: std.ArrayListUnmanaged(nodepkg.PathNode) = .{};
+        defer nodes.deinit(alloc);
+        try nodes.append(alloc, .{ .move_to = .{ .point = .{ .x = 10, .y = 10 } } });
+        try nodes.append(alloc, .{ .line_to = .{ .point = .{ .x = 10, .y = 10 } } });
+        try nodes.append(alloc, .{ .line_to = .{ .point = .{ .x = 20, .y = 20 } } });
 
         var plotter = try StrokePlotter.init(
             alloc,
@@ -696,7 +696,7 @@ test "assert ok: degenerate moveto -> lineto, then good lineto" {
             0.01,
             Transformation.identity,
         );
-        defer plotter.deinit();
+        defer plotter.deinit(alloc);
 
         var result = try plotter.plot(alloc, nodes.items);
         defer result.deinit(alloc);
@@ -713,11 +713,11 @@ test "assert ok: degenerate moveto -> lineto, then good lineto" {
     {
         // p1 -> p2 is equal
         const alloc = testing.allocator;
-        var nodes = std.ArrayList(nodepkg.PathNode).init(alloc);
-        defer nodes.deinit();
-        try nodes.append(.{ .move_to = .{ .point = .{ .x = 10, .y = 10 } } });
-        try nodes.append(.{ .line_to = .{ .point = .{ .x = 20, .y = 20 } } });
-        try nodes.append(.{ .line_to = .{ .point = .{ .x = 20, .y = 20 } } });
+        var nodes: std.ArrayListUnmanaged(nodepkg.PathNode) = .{};
+        defer nodes.deinit(alloc);
+        try nodes.append(alloc, .{ .move_to = .{ .point = .{ .x = 10, .y = 10 } } });
+        try nodes.append(alloc, .{ .line_to = .{ .point = .{ .x = 20, .y = 20 } } });
+        try nodes.append(alloc, .{ .line_to = .{ .point = .{ .x = 20, .y = 20 } } });
 
         var plotter = try StrokePlotter.init(
             alloc,
@@ -729,7 +729,7 @@ test "assert ok: degenerate moveto -> lineto, then good lineto" {
             0.01,
             Transformation.identity,
         );
-        defer plotter.deinit();
+        defer plotter.deinit(alloc);
 
         var result = try plotter.plot(alloc, nodes.items);
         defer result.deinit(alloc);

--- a/src/painter.zig
+++ b/src/painter.zig
@@ -195,7 +195,7 @@ pub fn stroke(
         @max(opts.tolerance, 0.001),
         opts.transformation,
     );
-    defer plotter.deinit();
+    defer plotter.deinit(alloc);
 
     var polygons = try plotter.plot(alloc, nodes);
     defer polygons.deinit(alloc);


### PR DESCRIPTION
There were a couple of ArrayLists that were set up to be managed that didn't need to be, mainly in tests but also in Pen. This has been fixed now.

Also removed Pen.verticesFor as we are not using it, requires allocation, and we were storing the allocator for it - oops!