### PR TITLE
Make Tracy Profiler a lazy dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -114,21 +114,6 @@ pub fn build(b: *std.Build) void {
     });
 
     /////////////////////////////////////////////////////////////////////////
-    // Development dependencies
-    /////////////////////////////////////////////////////////////////////////
-    const tracy_enable = b.option(
-        bool,
-        "tracy",
-        "Enable Tracy profiler support (needs to be run with the \"spec\" target)",
-    );
-    const tracy_dep = b.dependency("zig-tracy", .{
-        .target = target,
-        .optimize = optimize,
-        .tracy_enable = tracy_enable orelse false,
-        .tracy_callstack = @as(u8, @intCast(32)),
-    });
-
-    /////////////////////////////////////////////////////////////////////////
     // Unit tests
     /////////////////////////////////////////////////////////////////////////
     const test_filters = b.option(
@@ -156,6 +141,12 @@ pub fn build(b: *std.Build) void {
         "update",
         "Update spec (E2E) tests (needs to be run with the \"spec\" target)",
     );
+    const tracy_enable = b.option(
+        bool,
+        "tracy",
+        "Enable Tracy profiler support (needs to be run with the \"spec\" target)",
+    );
+
     const spec_test = spec: {
         if (spec_update orelse false)
             break :spec b.addExecutable(.{
@@ -174,9 +165,20 @@ pub fn build(b: *std.Build) void {
             });
     };
     spec_test.root_module.addImport("z2d", z2d);
-    spec_test.root_module.addImport("tracy", tracy_dep.module("tracy"));
-    spec_test.linkLibrary(tracy_dep.artifact("tracy"));
-    spec_test.linkLibCpp();
+    const spec_options = b.addOptions();
+    spec_options.addOption(bool, "tracy_enable", tracy_enable orelse false);
+    spec_test.root_module.addOptions("spec_options", spec_options);
+    if (tracy_enable orelse false) tracy: {
+        const tracy_dep = b.lazyDependency("zig-tracy", .{
+            .target = target,
+            .optimize = optimize,
+            .tracy_enable = tracy_enable orelse false,
+            .tracy_callstack = @as(u8, @intCast(32)),
+        }) orelse break :tracy;
+        spec_test.root_module.addImport("tracy", tracy_dep.module("tracy"));
+        spec_test.linkLibrary(tracy_dep.artifact("tracy"));
+        spec_test.linkLibCpp();
+    }
     const spec_run = b.addRunArtifact(spec_test);
     b.step("spec", "Run spec (E2E) tests").dependOn(&spec_run.step);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,6 +7,7 @@
         .@"zig-tracy" = .{
             .url = "git+https://github.com/vancluever/zig-tracy?ref=fix-callstack#6e123ee26032e49a1a0039524ddf7970692931d9",
             .hash = "122094fc39764bd527269d3721f52fc3b8cbb72bc4cdbd3345cbc2cd941936f3d185",
+            .lazy = true,
         },
     },
     .paths = .{

--- a/spec/main.zig
+++ b/spec/main.zig
@@ -10,7 +10,8 @@ const sha256 = @import("std").crypto.hash.sha2.Sha256;
 const testing = @import("std").testing;
 
 const z2d = @import("z2d");
-const tracy = @import("tracy");
+const tracy_enable = @import("spec_options").tracy_enable;
+const tracy = if (tracy_enable) @import("tracy") else null;
 
 const _001_smile_rgb = @import("001_smile_rgb.zig");
 const _002_smile_rgba = @import("002_smile_rgba.zig");
@@ -423,22 +424,30 @@ fn compositorTestRun(alloc: mem.Allocator, subject: anytype) !void {
         .{ subject.filename, ".png" },
     );
     defer alloc.free(filename);
+    var exported_file: testExportPNGDetails = undefined;
 
-    var tracy_alloc_ = tracy.TracingAllocator.init(alloc);
-    const tracy_alloc = tracy_alloc_.allocator();
+    if (tracy_enable) {
+        var tracy_alloc_ = tracy.TracingAllocator.init(alloc);
+        const tracy_alloc = tracy_alloc_.allocator();
 
-    var surface = surface: {
-        const zone = tracy.initZone(@src(), .{ .name = "compositorTestRun: render" });
-        defer zone.deinit();
-        break :surface try subject.render(tracy_alloc);
-    };
-    defer surface.deinit(tracy_alloc);
+        var surface = surface: {
+            const zone = tracy.initZone(@src(), .{ .name = "compositorTestRun: render" });
+            defer zone.deinit();
+            break :surface try subject.render(tracy_alloc);
+        };
+        defer surface.deinit(tracy_alloc);
 
-    var exported_file = exported_file: {
-        const zone = tracy.initZone(@src(), .{ .name = "compositorTestRun: export" });
-        defer zone.deinit();
-        break :exported_file try testExportPNG(tracy_alloc, surface, filename);
-    };
+        exported_file = exported_file: {
+            const zone = tracy.initZone(@src(), .{ .name = "compositorTestRun: export" });
+            defer zone.deinit();
+            break :exported_file try testExportPNG(tracy_alloc, surface, filename);
+        };
+    } else {
+        var surface = try subject.render(alloc);
+        defer surface.deinit(alloc);
+
+        exported_file = try testExportPNG(alloc, surface, filename);
+    }
     defer exported_file.cleanup();
 
     try compareFiles(testing.allocator, exported_file.target_path);
@@ -458,42 +467,54 @@ fn pathTestRun(alloc: mem.Allocator, subject: anytype) !void {
     );
     defer alloc.free(filename_smooth);
 
-    var tracy_alloc_ = tracy.TracingAllocator.init(alloc);
-    const tracy_alloc = tracy_alloc_.allocator();
+    var exported_file_pixelated: testExportPNGDetails = undefined;
+    var exported_file_smooth: testExportPNGDetails = undefined;
 
-    var surface_pixelated = surface_pixelated: {
-        const zone = tracy.initZone(@src(), .{ .name = "pathTestRun: render (aa_mode = .none)" });
-        defer zone.deinit();
-        break :surface_pixelated try subject.render(tracy_alloc, .none);
-    };
-    defer surface_pixelated.deinit(tracy_alloc);
-    var surface_smooth = surface_smooth: {
-        const zone = tracy.initZone(@src(), .{ .name = "pathTestRun: render (aa_mode = .default)" });
-        defer zone.deinit();
-        break :surface_smooth try subject.render(tracy_alloc, .default);
-    };
-    defer surface_smooth.deinit(tracy_alloc);
+    if (tracy_enable) {
+        var tracy_alloc_ = tracy.TracingAllocator.init(alloc);
+        const tracy_alloc = tracy_alloc_.allocator();
 
-    var exported_file_pixelated = exported_file_pixelated: {
-        const zone = tracy.initZone(@src(), .{ .name = "pathTestRun: export (aa_mode = .none)" });
-        defer zone.deinit();
-        break :exported_file_pixelated try testExportPNG(
-            tracy_alloc,
-            surface_pixelated,
-            filename_pixelated,
-        );
-    };
+        var surface_pixelated = surface_pixelated: {
+            const zone = tracy.initZone(@src(), .{ .name = "pathTestRun: render (aa_mode = .none)" });
+            defer zone.deinit();
+            break :surface_pixelated try subject.render(tracy_alloc, .none);
+        };
+        defer surface_pixelated.deinit(tracy_alloc);
+        var surface_smooth = surface_smooth: {
+            const zone = tracy.initZone(@src(), .{ .name = "pathTestRun: render (aa_mode = .default)" });
+            defer zone.deinit();
+            break :surface_smooth try subject.render(tracy_alloc, .default);
+        };
+        defer surface_smooth.deinit(tracy_alloc);
+
+        exported_file_pixelated = exported_file_pixelated: {
+            const zone = tracy.initZone(@src(), .{ .name = "pathTestRun: export (aa_mode = .none)" });
+            defer zone.deinit();
+            break :exported_file_pixelated try testExportPNG(
+                tracy_alloc,
+                surface_pixelated,
+                filename_pixelated,
+            );
+        };
+        exported_file_smooth = exported_file_smooth: {
+            const zone = tracy.initZone(@src(), .{ .name = "pathTestRun: export (aa_mode = .default)" });
+            defer zone.deinit();
+            break :exported_file_smooth try testExportPNG(
+                tracy_alloc,
+                surface_smooth,
+                filename_smooth,
+            );
+        };
+    } else {
+        var surface_pixelated = try subject.render(alloc, .none);
+        defer surface_pixelated.deinit(alloc);
+        var surface_smooth = try subject.render(alloc, .default);
+        defer surface_smooth.deinit(alloc);
+
+        exported_file_pixelated = try testExportPNG(alloc, surface_pixelated, filename_pixelated);
+        exported_file_smooth = try testExportPNG(alloc, surface_smooth, filename_smooth);
+    }
     defer exported_file_pixelated.cleanup();
-
-    var exported_file_smooth = exported_file_smooth: {
-        const zone = tracy.initZone(@src(), .{ .name = "pathTestRun: export (aa_mode = .default)" });
-        defer zone.deinit();
-        break :exported_file_smooth try testExportPNG(
-            tracy_alloc,
-            surface_smooth,
-            filename_smooth,
-        );
-    };
     defer exported_file_smooth.cleanup();
 
     try compareFiles(testing.allocator, exported_file_pixelated.target_path);


### PR DESCRIPTION
This makes Tracy a lazy dependency so that neither zig-tracy nor the Tracy source are pulled in  when they're not needed (normal use of the library, running unit tests, running E2E tests with Tracy disabled).

Some conditional importing and code adjustments needed to be made to the E2E tests to make this happen to ensure that zig-tracy was only imported when it was going to be available.