### PR TITLE
Dasher: fix/spin off validation logic

### DIFF
--- a/src/internal/Dasher.zig
+++ b/src/internal/Dasher.zig
@@ -4,22 +4,28 @@
 //! Used to keep track of dash state.
 const Dasher = @This();
 
+const testing = @import("std").testing;
+
 dashes: []const f64,
 offset: f64,
 idx: usize,
 on: bool,
 remain: f64,
 
-pub fn init(dashes: []const f64, offset: f64) ?Dasher {
-    if (dashes.len == 0) return null;
+pub fn validate(dashes: []const f64) bool {
     var valid = false;
     for (dashes) |d| {
         if (d < 0) {
-            break;
+            return false;
         }
-        valid = true;
+        if (d > 0) {
+            valid = true;
+        }
     }
-    if (!valid) return null;
+    return valid;
+}
+
+pub fn init(dashes: []const f64, offset: f64) Dasher {
     var result: Dasher = .{
         .dashes = dashes,
         .offset = offset,
@@ -66,4 +72,27 @@ pub fn step(self: *Dasher, len: f64) bool {
     }
 
     return stepped;
+}
+
+test "validate" {
+    // Good (single)
+    try testing.expect(validate(&.{1}));
+
+    // Good (even)
+    try testing.expect(validate(&.{ 1, 2 }));
+
+    // Good (odd)
+    try testing.expect(validate(&.{ 1, 2, 3 }));
+
+    // Good (zero stops)
+    try testing.expect(validate(&.{ 0, 2, 0 }));
+
+    // Bad (single zero)
+    try testing.expect(!validate(&.{0}));
+
+    // Bad (all zeroes)
+    try testing.expect(!validate(&.{ 0, 0, 0 }));
+
+    // Bad (negative value)
+    try testing.expect(!validate(&.{ 1, -2, 3 }));
 }

--- a/src/internal/dashed_plotter.zig
+++ b/src/internal/dashed_plotter.zig
@@ -33,9 +33,11 @@ const Error = @import("stroke_plotter.zig").Error;
 pub fn plot(
     alloc: mem.Allocator,
     nodes: []const nodepkg.PathNode,
-    dasher: Dasher,
     opts: PlotterOptions,
 ) Error!PolygonList {
+    // NOTE: `opts.dashes` needs to be validated separately before calling this
+    // - this is done from `stroke_plotter.plot` in normal operation. Be
+    // cognizant of this if you plan on calling this directly!
     var plotter: Plotter = .{
         .alloc = alloc,
         .nodes = nodes,
@@ -50,7 +52,7 @@ pub fn plot(
         .poly_outer = .{ .scale = opts.scale },
         .poly_inner = .{ .scale = opts.scale },
 
-        .dasher = dasher,
+        .dasher = Dasher.init(opts.dashes, opts.dash_offset),
     };
 
     errdefer {

--- a/src/internal/stroke_plotter.zig
+++ b/src/internal/stroke_plotter.zig
@@ -41,8 +41,8 @@ pub fn plot(
     nodes: []const nodepkg.PathNode,
     opts: PlotterOptions,
 ) Error!PolygonList {
-    if (Dasher.init(opts.dashes, opts.dash_offset)) |dasher| {
-        return dashed_plotter.plot(alloc, nodes, dasher, opts);
+    if (Dasher.validate(opts.dashes)) {
+        return dashed_plotter.plot(alloc, nodes, opts);
     }
 
     var plotter: Plotter = .{


### PR DESCRIPTION
There was an issue in the validation logic that would have allowed the full-zero case to go through. This has now been fixed (there has to be at least one greater-than-zero element present in order to be valid, with no negative values).

The validation logic has also been spun off from init so that the dasher is initialized in the dash plotter versus the generic stroke plotter. This was a minor issue that I missed fixing before 0.5.0 - it should avoid a minor amount of stack overhead and a copy, not a huge deal, but these are things I'm trying to be more cognizant of going forward.