### PR TITLE
Compositor overhaul, introduce strides

### DIFF
--- a/spec/023_smile_alpha_mask.zig
+++ b/spec/023_smile_alpha_mask.zig
@@ -63,11 +63,11 @@ pub fn render(alloc: mem.Allocator) !z2d.Surface {
     var foreground_sfc = try z2d.Surface.initPixel(foregrounds[0], alloc, image.width, image.height);
     defer foreground_sfc.deinit(alloc);
     // Apply mask to foreground
-    foreground_sfc.dstIn(&mask_sfc, 0, 0);
+    foreground_sfc.composite(&mask_sfc, .in, 0, 0);
     // Apply foreground to background
-    background_sfc.srcOver(&foreground_sfc, 0, 0);
+    background_sfc.composite(&foreground_sfc, .over, 0, 0);
     // Composite our working surface at our first offset co-ordinates
-    result_sfc.srcOver(&background_sfc, 12, 13);
+    result_sfc.composite(&background_sfc, .over, 12, 13);
 
     // 2nd smile
     //
@@ -75,11 +75,11 @@ pub fn render(alloc: mem.Allocator) !z2d.Surface {
     background_sfc.paintPixel(backgrounds[1]);
     // Re-paint foreground and apply mask
     foreground_sfc.paintPixel(foregrounds[1]);
-    foreground_sfc.dstIn(&mask_sfc, 0, 0);
+    foreground_sfc.composite(&mask_sfc, .in, 0, 0);
     // Apply foreground to background
-    background_sfc.srcOver(&foreground_sfc, 0, 0);
+    background_sfc.composite(&foreground_sfc, .over, 0, 0);
     // Composite our working surface at our second offset co-ordinates
-    result_sfc.srcOver(&background_sfc, w / 2 - 7, 13);
+    result_sfc.composite(&background_sfc, .over, w / 2 - 7, 13);
 
     // 3rd smile
     //
@@ -87,11 +87,11 @@ pub fn render(alloc: mem.Allocator) !z2d.Surface {
     background_sfc.paintPixel(backgrounds[2]);
     // Re-paint foreground and apply mask
     foreground_sfc.paintPixel(foregrounds[2]);
-    foreground_sfc.dstIn(&mask_sfc, 0, 0);
+    foreground_sfc.composite(&mask_sfc, .in, 0, 0);
     // Apply foreground to background
-    background_sfc.srcOver(&foreground_sfc, 0, 0);
+    background_sfc.composite(&foreground_sfc, .over, 0, 0);
     // Composite our working surface at our second offset co-ordinates
-    result_sfc.srcOver(&background_sfc, w / 4 + 2, h / 2 - 7);
+    result_sfc.composite(&background_sfc, .over, w / 4 + 2, h / 2 - 7);
 
     // done!
 

--- a/src/compositor.zig
+++ b/src/compositor.zig
@@ -1,0 +1,842 @@
+// SPDX-License-Identifier: MPL-2.0
+//   Copyright © 2024 Chris Marchesi
+
+const debug = @import("std").debug;
+const simd = @import("std").simd;
+const testing = @import("std").testing;
+
+const pixel = @import("pixel.zig");
+const Surface = @import("surface.zig").Surface;
+
+/// The length of vector operations. This is CPU-dependent, with a minimum of 8
+/// to provide adequate scaling for CPU architectures that lack SIMD or
+/// extensions that Zig does not recognize. Architectures with SIMD registers
+/// smaller than 128 bits will just have the 8 vectors serialized into 2
+/// batches of 4.
+pub const vector_length = @max(simd.suggestVectorLength(u16) orelse 8, 8); // TODO: scalar fallback?
+
+/// The list of supported operators.
+///
+/// Note that all supported operations require pre-multiplied alpha
+/// (`RGBA.multiply` can be used to multiply values before setting them as
+/// sources.)
+pub const Operator = enum {
+    /// The part of the destination laying inside of the source replaces the
+    /// destination.
+    in,
+
+    /// The source is composited on the destination.
+    over,
+
+    fn run(op: Operator, dst: anytype, src: anytype, max: anytype) @TypeOf(dst, src) {
+        return switch (op) {
+            .in => in(dst, src, max),
+            .over => over(dst, src, max),
+        };
+    }
+};
+
+/// Compositor functionality that operates at surface-scoped levels of
+/// granularity.
+pub const SurfaceCompositor = struct {
+    /// An individual operation in a surface-level composition batch.
+    pub const Operation = struct {
+        /// The composition operator for this operation.
+        operator: Operator,
+
+        /// Overrides the destination in this operation if set to anything else
+        /// other than `.none`.
+        dst: Param = .{ .none = {} },
+
+        /// Sets the source for this operation. Required for the first operation in
+        /// the batch; setting to `.none` in this case is a no-op.
+        src: Param = .{ .none = {} },
+
+        /// Represents a parameter for a surface-level composition operation.
+        const Param = union(enum) {
+            /// No value - operation uses default/current dst/src.
+            none: void,
+
+            /// Represents a single pixel used for the whole of the source or
+            /// destination.
+            ///
+            /// When supplied as the initial source, bounds the operation to
+            /// entirety of the destination. In this case, the composition must be
+            /// positioned at the origin of destination (i.e., dst_x=0, dst_y=0),
+            /// if it isn't, it's a no-op.
+            pixel: pixel.Pixel,
+
+            /// Represents a surface to use in this operation.
+            ///
+            /// When set in the initial operation's `src` field, sets the bounds
+            /// for the composition.
+            ///
+            /// If set in an operation under the first, the surface takes over for
+            /// the `dst` or `src`, acting as if the working source or destination
+            /// in exactly the same co-ordinates and dimensions. Any situation
+            /// where either the destination or source is smaller than the
+            /// originals can cause wrapping or safety-checked undefined behavior.
+            surface: *const Surface,
+        };
+    };
+
+    /// Runs a batch of multiple compositor operations in succession using the
+    /// operation data provided. Unless otherwise supplied, each operation uses
+    /// the source data from the last operation, with the exception of the
+    /// first operation, where the source must be supplied.
+    ///
+    /// The batch is oriented at `(dst_x, dst_y)`, with the bounding area taken
+    /// from the first source (see `Operation.Param` for more details). When
+    /// bounded to the source, Any parts of the source outside of the
+    /// destination are ignored.
+    pub fn run(
+        dst: *Surface,
+        dst_x: i32,
+        dst_y: i32,
+        comptime operations_len: usize,
+        operations: [operations_len]Operation,
+    ) void {
+        // No-op if no operations
+        if (operations.len == 0) return;
+        // No-op if we'd just be drawing out of bounds of the surface
+        if (dst_x >= dst.getWidth() or dst_y >= dst.getHeight()) return;
+
+        // Check the first element to set our bounding info.
+        const src_dimensions: struct {
+            width: i32,
+            height: i32,
+        } = switch (operations[0].src) {
+            .none => return,
+            .pixel => pixel: {
+                // We have a pixel source - this is allowed since we could allow
+                // blends of a single pixel across the entirety of a surface. We do
+                // have some constraints, however - specifically, dst_x and dst_y
+                // have to be zero, so that we paint the entire surface.
+                if (dst_x != 0 or dst_y != 0) return;
+                break :pixel .{
+                    .width = dst.getWidth(),
+                    .height = dst.getHeight(),
+                };
+            },
+            .surface => |sfc| .{
+                .width = sfc.getWidth(),
+                .height = sfc.getHeight(),
+            },
+        };
+
+        const src_start_y: i32 = if (dst_y < 0) @intCast(@abs(dst_y)) else 0;
+        const src_start_x: i32 = if (dst_x < 0) @intCast(@abs(dst_x)) else 0;
+
+        // Compute our actual drawing dimensions.
+        const height = if (src_dimensions.height + dst_y > dst.getHeight())
+            dst.getHeight() - dst_y
+        else
+            src_dimensions.height;
+        const width = if (src_dimensions.width + dst_x > dst.getWidth())
+            dst.getWidth() - dst_x
+        else
+            src_dimensions.width;
+
+        var src_y = src_start_y;
+        while (src_y < height) : (src_y += 1) {
+            const dst_start_x = src_start_x + dst_x;
+            const dst_start_y = src_y + dst_y;
+            const len: usize = @intCast(width - src_start_x);
+            // Get our destination stride
+            const _dst = dst.getStride(dst_start_x, dst_start_y, len);
+            // Build our batch for this line
+            const stride_ops: [operations_len]StrideCompositor.Operation = stride_ops: {
+                var stride_op: [operations_len]StrideCompositor.Operation = undefined;
+                for (operations, 0..) |op, idx| {
+                    stride_op[idx].operator = op.operator;
+                    stride_op[idx].dst = switch (op.dst) {
+                        .surface => |sfc| .{ .stride = sfc.getStride(dst_start_x, dst_start_y, len) },
+                        .none => .{ .none = {} },
+                        .pixel => |px| .{ .pixel = px },
+                    };
+                    stride_op[idx].src = switch (op.src) {
+                        .surface => |sfc| .{ .stride = sfc.getStride(src_start_x, src_y, len) },
+                        .none => .{ .none = {} },
+                        .pixel => |px| .{ .pixel = px },
+                    };
+                }
+                break :stride_ops stride_op;
+            };
+            // Run the batch
+            StrideCompositor.run(_dst, &stride_ops);
+        }
+    }
+};
+
+/// Compositor functionality that operates at stride-scoped levels of
+/// granularity.
+pub const StrideCompositor = struct {
+    /// An individual operation in the stride-level composition batch.
+    const Operation = struct {
+        /// The composition operator for this operation.
+        operator: Operator,
+
+        /// Overrides the destination in this operation if set to anything else
+        /// other than `.none`.
+        dst: Param = .{ .none = {} },
+
+        /// Sets the source for this operation. Required for the first operation in
+        /// the batch; setting to `.none` in this case causes safety-checked
+        /// undefined behavior.
+        src: Param = .{ .none = {} },
+
+        /// Represents a parameter for a stride-level composition operation.
+        pub const Param = union(enum) {
+            /// No value - operation uses default/current dst/src.
+            none: void,
+
+            /// Represents a single pixel, used individually or broadcast across a
+            /// vector depending on the operation.
+            pixel: pixel.Pixel,
+
+            /// Represents a stride of pixel data. Must be as long or longer
+            /// than the main destination; shorter strides will cause
+            /// safety-checked undefined behavior.
+            stride: pixel.Stride,
+        };
+    };
+
+    /// Runs a batch of multiple compositor operations in succession using the
+    /// operation data provided. Unless otherwise supplied, each operation uses
+    /// the source data from the last operation, with the exception of the
+    /// first operation, where the source must be supplied.
+    ///
+    /// The batch is bounded to the destination stride provided, which means
+    /// that each stride supplied as a source must have as many pixels or more
+    /// as the destination, and any pixels outside of the destination length
+    /// are ignored. Supplying a source stride shorter than the destination is
+    /// safety-checked undefined behavior.
+    pub fn run(dst: pixel.Stride, operations: []const Operation) void {
+        const len = dst.pxLen();
+        for (0..len / vector_length) |i| {
+            // Vector section - we step on the vector length, and operate on each.
+            // The working result does not leave the vectors (unless overridden).
+            const j = i * vector_length;
+            var _dst: RGBA16Vec = undefined;
+            var _src: RGBA16Vec = undefined;
+            for (operations, 0..) |op, op_idx| {
+                _src = switch (op.src) {
+                    .pixel => |px| RGBA16Vec.fromPixel(px),
+                    .stride => |stride| RGBA16Vec.fromStride(stride, j),
+                    .none => none: {
+                        debug.assert(op_idx != 0);
+                        break :none _dst;
+                    },
+                };
+                _dst = switch (op.dst) {
+                    .pixel => |px| RGBA16Vec.fromPixel(px),
+                    .stride => |stride| RGBA16Vec.fromStride(stride, j),
+                    .none => RGBA16Vec.fromStride(dst, j),
+                };
+                _dst = op.operator.run(_dst, _src, max_u8_vec);
+            }
+            // End of the batch for this vector, so we can write it out now.
+            _dst.toStride(dst, j);
+        }
+        for (len - len % vector_length..len) |i| {
+            // Scalar section, we step on this element-by-element.
+            var _dst: RGBA16 = undefined;
+            var _src: RGBA16 = undefined;
+            for (operations, 0..) |op, op_idx| {
+                _src = switch (op.src) {
+                    .pixel => |px| RGBA16.fromPixel(px),
+                    .stride => |stride| RGBA16.fromPixel(getPixelFromStride(stride, i)),
+                    .none => none: {
+                        debug.assert(op_idx != 0);
+                        break :none _dst;
+                    },
+                };
+                _dst = switch (op.dst) {
+                    .pixel => |px| RGBA16.fromPixel(px),
+                    .stride => |stride| RGBA16.fromPixel(getPixelFromStride(stride, i)),
+                    .none => RGBA16.fromPixel(getPixelFromStride(dst, i)),
+                };
+                _dst = op.operator.run(_dst, _src, max_u8_scalar);
+            }
+
+            setPixelInStride(dst, i, _dst.toPixel());
+        }
+    }
+};
+
+/// Runs a single compositor operation described by `operator` against the
+/// supplied pixels.
+pub fn runPixel(dst: pixel.Pixel, src: pixel.Pixel, operator: Operator) pixel.Pixel {
+    const _dst = RGBA16.fromPixel(dst);
+    const _src = RGBA16.fromPixel(src);
+    return switch (dst) {
+        inline else => |d| @TypeOf(d).fromPixel(
+            operator.run(_dst, _src, max_u8_scalar).toPixel(),
+        ).asPixel(),
+    };
+}
+
+const max_u8_scalar: u16 = 255;
+const max_u8_vec: @Vector(vector_length, u16) = @splat(255);
+const zero_int_vec: @Vector(vector_length, u16) = @splat(0);
+
+/// Represents an RGBA value as 16bpc. Note that this is only for intermediary
+/// calculations, no channel should be bigger than an u8 after any particular
+/// compositor step.
+const RGBA16 = struct {
+    r: u16,
+    g: u16,
+    b: u16,
+    a: u16,
+
+    fn fromPixel(src: pixel.Pixel) RGBA16 {
+        const _src = pixel.RGBA.fromPixel(src);
+        return .{
+            .r = _src.r,
+            .g = _src.g,
+            .b = _src.b,
+            .a = _src.a,
+        };
+    }
+
+    fn toPixel(src: RGBA16) pixel.Pixel {
+        return .{ .rgba = .{
+            .r = @intCast(src.r),
+            .g = @intCast(src.g),
+            .b = @intCast(src.b),
+            .a = @intCast(src.a),
+        } };
+    }
+};
+
+/// Represents an RGBA value as a series of 16bpc vectors. Note that this is
+/// only for intermediary calculations, no channel should be bigger than an u8
+/// after any particular compositor step.
+const RGBA16Vec = struct {
+    r: @Vector(vector_length, u16),
+    g: @Vector(vector_length, u16),
+    b: @Vector(vector_length, u16),
+    a: @Vector(vector_length, u16),
+
+    fn fromPixel(src: pixel.Pixel) RGBA16Vec {
+        const _src = pixel.RGBA.fromPixel(src);
+        return .{
+            .r = @splat(_src.r),
+            .g = @splat(_src.g),
+            .b = @splat(_src.b),
+            .a = @splat(_src.a),
+        };
+    }
+
+    fn fromStride(src: pixel.Stride, idx: usize) RGBA16Vec {
+        switch (src) {
+            inline .rgb, .rgba, .alpha8 => |_src| {
+                const src_t = @typeInfo(@TypeOf(_src)).Pointer.child;
+                const has_color = src_t == pixel.RGB or src_t == pixel.RGBA;
+                const has_alpha = src_t == pixel.RGBA or src_t == pixel.Alpha8;
+                return .{
+                    .r = if (has_color) transposeToVec(_src[idx .. idx + vector_length], .r) else zero_int_vec,
+                    .g = if (has_color) transposeToVec(_src[idx .. idx + vector_length], .g) else zero_int_vec,
+                    .b = if (has_color) transposeToVec(_src[idx .. idx + vector_length], .b) else zero_int_vec,
+                    .a = if (has_alpha) transposeToVec(_src[idx .. idx + vector_length], .a) else max_u8_vec,
+                };
+            },
+            inline .alpha4, .alpha2, .alpha1 => |_src| {
+                var result: RGBA16Vec = undefined;
+                for (0..vector_length) |i| {
+                    const px = pixel.Alpha8.fromPixel(
+                        @TypeOf(_src).T.getFromPacked(_src.buf, _src.px_offset + idx + i).asPixel(),
+                    );
+                    result.r[i] = 0;
+                    result.g[i] = 0;
+                    result.b[i] = 0;
+                    result.a[i] = px.a;
+                }
+                return result;
+            },
+        }
+    }
+
+    fn toStride(self: RGBA16Vec, dst: pixel.Stride, idx: usize) void {
+        switch (dst) {
+            inline .rgb, .rgba, .alpha8 => |_dst| {
+                const dst_t = @typeInfo(@TypeOf(_dst)).Pointer.child;
+                const has_color = dst_t == pixel.RGB or dst_t == pixel.RGBA;
+                const has_alpha = dst_t == pixel.RGBA or dst_t == pixel.Alpha8;
+                if (has_color) transposeFromVec(_dst[idx .. idx + vector_length], self.r, .r);
+                if (has_color) transposeFromVec(_dst[idx .. idx + vector_length], self.g, .g);
+                if (has_color) transposeFromVec(_dst[idx .. idx + vector_length], self.b, .b);
+                if (has_alpha) transposeFromVec(_dst[idx .. idx + vector_length], self.a, .a);
+            },
+            inline .alpha4, .alpha2, .alpha1 => |_dst| {
+                for (0..vector_length) |i| {
+                    const dst_t = @TypeOf(_dst).T;
+                    dst_t.setInPacked(
+                        _dst.buf,
+                        _dst.px_offset + idx + i,
+                        dst_t.fromPixel(.{ .alpha8 = .{ .a = @intCast(self.a[i]) } }),
+                    );
+                }
+            },
+        }
+    }
+};
+
+/// Short-hand helpers so that we do not need to print raw strings in code.
+/// Should line up with the fields of RGBA16Vec.
+const VecField = enum {
+    r,
+    g,
+    b,
+    a,
+};
+
+fn transposeToVec(arr: anytype, comptime field: VecField) @Vector(vector_length, u16) {
+    var result: @Vector(vector_length, u16) = undefined;
+    for (0..vector_length) |idx| result[idx] = @field(arr[idx], @tagName(field));
+    return result;
+}
+
+fn transposeFromVec(arr: anytype, src: @Vector(vector_length, u16), comptime field: VecField) void {
+    for (0..vector_length) |idx| @field(arr[idx], @tagName(field)) = @intCast(src[idx]);
+}
+
+fn getPixelFromStride(src: pixel.Stride, idx: usize) pixel.Pixel {
+    return switch (src) {
+        inline .rgb, .rgba, .alpha8 => |_src| _src[idx].asPixel(),
+        inline .alpha4, .alpha2, .alpha1 => |_src| @TypeOf(_src).T.getFromPacked(
+            _src.buf,
+            _src.px_offset + idx,
+        ).asPixel(),
+    };
+}
+
+fn setPixelInStride(dst: pixel.Stride, idx: usize, px: pixel.Pixel) void {
+    return switch (dst) {
+        inline .rgb, .rgba, .alpha8 => |_dst| {
+            _dst[idx] = @typeInfo(@TypeOf(_dst)).Pointer.child.fromPixel(px);
+        },
+        inline .alpha4, .alpha2, .alpha1 => |_dst| {
+            const dst_t = @TypeOf(_dst).T;
+            dst_t.setInPacked(
+                _dst.buf,
+                _dst.px_offset + idx,
+                dst_t.fromPixel(px),
+            );
+        },
+    };
+}
+
+fn in(dst: anytype, src: anytype, max: anytype) @TypeOf(dst, src) {
+    return .{
+        .r = dst.r * src.a / max,
+        .g = dst.g * src.a / max,
+        .b = dst.b * src.a / max,
+        .a = dst.a * src.a / max,
+    };
+}
+
+fn over(dst: anytype, src: anytype, max: anytype) @TypeOf(dst, src) {
+    return .{
+        .r = src.r + dst.r * (max - src.a) / max,
+        .g = src.g + dst.g * (max - src.a) / max,
+        .b = src.b + dst.b * (max - src.a) / max,
+        .a = src.a + dst.a - src.a * dst.a / max,
+    };
+}
+
+test "over" {
+    // Our colors, non-pre-multiplied.
+    //
+    // Note that some tests require the pre-multiplied alpha. For these, we do
+    // the multiplication at the relevant site, as as most casts will drop
+    // either the non-color or alpha channels.
+    const fg: pixel.RGBA = .{ .r = 54, .g = 10, .b = 63, .a = 191 }; // purple, 75% opacity
+    const bg: pixel.RGBA = .{ .r = 15, .g = 254, .b = 249, .a = 229 }; // turquoise, 90% opacity
+
+    {
+        // RGB
+        const fg_rgb = pixel.RGB.fromPixel(fg.asPixel());
+        const bg_rgb = pixel.RGB.fromPixel(bg.asPixel());
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgb = fg_rgb },
+            runPixel(bg_rgb.asPixel(), fg_rgb.asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgb = .{ .r = 43, .g = 70, .b = 109 } },
+            runPixel(bg_rgb.asPixel(), fg.multiply().asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgb = .{ .r = 3, .g = 63, .b = 62 } },
+            runPixel(bg_rgb.asPixel(), pixel.Alpha8.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgb = .{ .r = 4, .g = 67, .b = 66 } },
+            runPixel(bg_rgb.asPixel(), pixel.Alpha4.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgb = .{ .r = 5, .g = 84, .b = 83 } },
+            runPixel(bg_rgb.asPixel(), pixel.Alpha2.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgb = .{ .r = 0, .g = 0, .b = 0 } },
+            runPixel(bg_rgb.asPixel(), .{ .alpha1 = .{ .a = 1 } }, .over),
+        );
+    }
+
+    {
+        // RGBA
+        const bg_mul = bg.multiply();
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgba = .{ .r = 54, .g = 10, .b = 63, .a = 255 } },
+            runPixel(bg_mul.asPixel(), pixel.RGB.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgba = .{ .r = 43, .g = 64, .b = 102, .a = 249 } },
+            runPixel(bg_mul.asPixel(), fg.multiply().asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgba = .{ .r = 3, .g = 57, .b = 55, .a = 249 } },
+            runPixel(bg_mul.asPixel(), pixel.Alpha8.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgba = .{ .r = 3, .g = 60, .b = 59, .a = 249 } },
+            runPixel(bg_mul.asPixel(), pixel.Alpha4.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgba = .{ .r = 4, .g = 76, .b = 74, .a = 247 } },
+            runPixel(bg_mul.asPixel(), pixel.Alpha2.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgba = .{ .r = 0, .g = 0, .b = 0, .a = 255 } },
+            runPixel(bg_mul.asPixel(), .{ .alpha1 = .{ .a = 1 } }, .over),
+        );
+    }
+
+    {
+        // Alpha8
+        const bg_alpha8 = pixel.Alpha8.fromPixel(bg.asPixel());
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha8 = .{ .a = 255 } },
+            runPixel(bg_alpha8.asPixel(), pixel.RGB.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha8 = .{ .a = 249 } },
+            runPixel(bg_alpha8.asPixel(), fg.asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha8 = .{ .a = 249 } },
+            runPixel(bg_alpha8.asPixel(), pixel.Alpha8.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha8 = .{ .a = 249 } },
+            runPixel(bg_alpha8.asPixel(), pixel.Alpha4.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha8 = .{ .a = 247 } },
+            runPixel(bg_alpha8.asPixel(), pixel.Alpha2.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha8 = .{ .a = 255 } },
+            runPixel(bg_alpha8.asPixel(), .{ .alpha1 = .{ .a = 1 } }, .over),
+        );
+    }
+
+    {
+        // Alpha4
+        const bg_alpha4 = pixel.Alpha4.fromPixel(bg.asPixel());
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha4 = .{ .a = 15 } },
+            runPixel(bg_alpha4.asPixel(), pixel.RGB.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha4 = .{ .a = 15 } },
+            runPixel(bg_alpha4.asPixel(), fg.asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha4 = .{ .a = 15 } },
+            runPixel(bg_alpha4.asPixel(), pixel.Alpha8.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha4 = .{ .a = 15 } },
+            runPixel(bg_alpha4.asPixel(), pixel.Alpha4.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha4 = .{ .a = 15 } },
+            runPixel(bg_alpha4.asPixel(), pixel.Alpha2.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha4 = .{ .a = 15 } },
+            runPixel(bg_alpha4.asPixel(), .{ .alpha1 = .{ .a = 1 } }, .over),
+        );
+    }
+
+    {
+        // Alpha2
+        const bg_alpha2 = pixel.Alpha2.fromPixel(bg.asPixel());
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha2 = .{ .a = 3 } },
+            runPixel(bg_alpha2.asPixel(), pixel.RGB.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha2 = .{ .a = 3 } },
+            runPixel(bg_alpha2.asPixel(), fg.asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha2 = .{ .a = 3 } },
+            runPixel(bg_alpha2.asPixel(), pixel.Alpha8.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha2 = .{ .a = 3 } },
+            runPixel(bg_alpha2.asPixel(), pixel.Alpha4.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha2 = .{ .a = 3 } },
+            runPixel(bg_alpha2.asPixel(), pixel.Alpha2.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha2 = .{ .a = 3 } },
+            runPixel(bg_alpha2.asPixel(), .{ .alpha1 = .{ .a = 1 } }, .over),
+        );
+    }
+
+    {
+        // Alpha1
+        var bg_alpha1 = pixel.Alpha1.fromPixel(bg.asPixel());
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 1 } },
+            runPixel(bg_alpha1.asPixel(), pixel.RGB.fromPixel(fg.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 1 } },
+            runPixel(bg_alpha1.asPixel(), fg.asPixel(), .over),
+        );
+        // Jack down our alpha channel by 1 to just demonstrate the error
+        // boundary when scaling down from u8 to u1.
+        var fg_127 = fg;
+        fg_127.a = 127;
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 1 } }, // Still 1 here due to our bg opacity being 90%
+            runPixel(bg_alpha1.asPixel(), fg_127.asPixel(), .over),
+        );
+
+        bg_alpha1.a = 0; // Turn off bg alpha layer for rest of testing
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 0 } },
+            runPixel(bg_alpha1.asPixel(), fg_127.asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 0 } },
+            runPixel(bg_alpha1.asPixel(), pixel.Alpha8.fromPixel(fg_127.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 0 } },
+            runPixel(bg_alpha1.asPixel(), pixel.Alpha4.fromPixel(fg_127.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 0 } },
+            runPixel(bg_alpha1.asPixel(), pixel.Alpha2.fromPixel(fg_127.asPixel()).asPixel(), .over),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 1 } },
+            runPixel(bg_alpha1.asPixel(), .{ .alpha1 = .{ .a = 1 } }, .over),
+        );
+    }
+}
+
+test "in" {
+    // Our colors, non-pre-multiplied.
+    //
+    // Note that some tests require the pre-multiplied alpha. For these, we do
+    // the multiplication at the relevant site, as as most casts will drop
+    // either the non-color or alpha channels.
+    const fg: pixel.RGBA = .{ .r = 54, .g = 10, .b = 63, .a = 191 }; // purple, 75% opacity
+    const bg: pixel.RGBA = .{ .r = 15, .g = 254, .b = 249, .a = 229 }; // turquoise, 90% opacity
+
+    {
+        // RGB
+        const fg_rgb = pixel.RGB.fromPixel(fg.asPixel());
+        const bg_rgb = pixel.RGB.fromPixel(bg.asPixel());
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgb = bg_rgb },
+            runPixel(bg_rgb.asPixel(), fg_rgb.asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgb = .{ .r = 11, .g = 190, .b = 186 } },
+            runPixel(bg_rgb.asPixel(), fg.multiply().asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgb = .{ .r = 11, .g = 190, .b = 186 } },
+            runPixel(bg_rgb.asPixel(), pixel.Alpha8.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgb = .{ .r = 11, .g = 186, .b = 182 } },
+            runPixel(bg_rgb.asPixel(), pixel.Alpha4.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgb = .{ .r = 10, .g = 169, .b = 166 } },
+            runPixel(bg_rgb.asPixel(), pixel.Alpha2.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgb = .{ .r = 15, .g = 254, .b = 249 } },
+            runPixel(bg_rgb.asPixel(), .{ .alpha1 = .{ .a = 1 } }, .in),
+        );
+    }
+
+    {
+        // RGBA
+        const bg_mul = bg.multiply();
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgba = .{ .r = 13, .g = 228, .b = 223, .a = 229 } },
+            runPixel(bg_mul.asPixel(), pixel.RGB.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgba = .{ .r = 9, .g = 170, .b = 167, .a = 171 } },
+            runPixel(bg_mul.asPixel(), fg.multiply().asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgba = .{ .r = 9, .g = 170, .b = 167, .a = 171 } },
+            runPixel(bg_mul.asPixel(), pixel.Alpha8.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgba = .{ .r = 9, .g = 167, .b = 163, .a = 167 } },
+            runPixel(bg_mul.asPixel(), pixel.Alpha4.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgba = .{ .r = 8, .g = 152, .b = 148, .a = 152 } },
+            runPixel(bg_mul.asPixel(), pixel.Alpha2.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .rgba = .{ .r = 13, .g = 228, .b = 223, .a = 229 } },
+            runPixel(bg_mul.asPixel(), .{ .alpha1 = .{ .a = 1 } }, .in),
+        );
+    }
+
+    {
+        // Alpha8
+        const bg_alpha8 = pixel.Alpha8.fromPixel(bg.asPixel());
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha8 = .{ .a = 229 } },
+            runPixel(bg_alpha8.asPixel(), pixel.RGB.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha8 = .{ .a = 171 } },
+            runPixel(bg_alpha8.asPixel(), fg.asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha8 = .{ .a = 171 } },
+            runPixel(bg_alpha8.asPixel(), pixel.Alpha8.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha8 = .{ .a = 167 } },
+            runPixel(bg_alpha8.asPixel(), pixel.Alpha4.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha8 = .{ .a = 152 } },
+            runPixel(bg_alpha8.asPixel(), pixel.Alpha2.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha8 = .{ .a = 229 } },
+            runPixel(bg_alpha8.asPixel(), .{ .alpha1 = .{ .a = 1 } }, .in),
+        );
+    }
+
+    {
+        // Alpha4
+        const bg_alpha4 = pixel.Alpha4.fromPixel(bg.asPixel());
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha4 = .{ .a = 14 } },
+            runPixel(bg_alpha4.asPixel(), pixel.RGB.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha4 = .{ .a = 11 } },
+            runPixel(bg_alpha4.asPixel(), fg.asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha4 = .{ .a = 11 } },
+            runPixel(bg_alpha4.asPixel(), pixel.Alpha8.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha4 = .{ .a = 10 } },
+            runPixel(bg_alpha4.asPixel(), pixel.Alpha4.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha4 = .{ .a = 9 } },
+            runPixel(bg_alpha4.asPixel(), pixel.Alpha2.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha4 = .{ .a = 14 } },
+            runPixel(bg_alpha4.asPixel(), .{ .alpha1 = .{ .a = 1 } }, .in),
+        );
+    }
+
+    {
+        // Alpha2
+        const bg_alpha2 = pixel.Alpha2.fromPixel(bg.asPixel());
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha2 = .{ .a = 3 } },
+            runPixel(bg_alpha2.asPixel(), pixel.RGB.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha2 = .{ .a = 2 } },
+            runPixel(bg_alpha2.asPixel(), fg.asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha2 = .{ .a = 2 } },
+            runPixel(bg_alpha2.asPixel(), pixel.Alpha8.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha2 = .{ .a = 2 } },
+            runPixel(bg_alpha2.asPixel(), pixel.Alpha4.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha2 = .{ .a = 2 } },
+            runPixel(bg_alpha2.asPixel(), pixel.Alpha2.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha2 = .{ .a = 3 } },
+            runPixel(bg_alpha2.asPixel(), .{ .alpha1 = .{ .a = 1 } }, .in),
+        );
+    }
+
+    {
+        // Alpha1
+        const bg_alpha1 = pixel.Alpha1.fromPixel(bg.asPixel());
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 1 } },
+            runPixel(bg_alpha1.asPixel(), pixel.RGB.fromPixel(fg.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 1 } },
+            runPixel(bg_alpha1.asPixel(), fg.asPixel(), .in),
+        );
+        // Jack down our alpha channel by 1 to just demonstrate the error
+        // boundary when scaling down from u8 to u1.
+        var fg_127 = fg;
+        fg_127.a = 127;
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 0 } },
+            runPixel(bg_alpha1.asPixel(), fg_127.asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 0 } },
+            runPixel(bg_alpha1.asPixel(), pixel.Alpha8.fromPixel(fg_127.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 0 } },
+            runPixel(bg_alpha1.asPixel(), pixel.Alpha4.fromPixel(fg_127.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 0 } },
+            runPixel(bg_alpha1.asPixel(), pixel.Alpha2.fromPixel(fg_127.asPixel()).asPixel(), .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 1 } },
+            runPixel(bg_alpha1.asPixel(), .{ .alpha1 = .{ .a = 1 } }, .in),
+        );
+        try testing.expectEqualDeep(
+            pixel.Pixel{ .alpha1 = .{ .a = 0 } },
+            runPixel(bg_alpha1.asPixel(), .{ .alpha1 = .{ .a = 0 } }, .in),
+        );
+    }
+}

--- a/src/surface.zig
+++ b/src/surface.zig
@@ -15,11 +15,13 @@
 //! details.
 
 const std = @import("std");
+const debug = @import("std").debug;
 const heap = @import("std").heap;
 const mem = @import("std").mem;
 const meta = @import("std").meta;
 const testing = @import("std").testing;
 
+const compositor = @import("compositor.zig");
 const pixel = @import("pixel.zig");
 
 /// The scale factor used for super-sample anti-aliasing. Any functionality
@@ -199,22 +201,23 @@ pub const Surface = union(SurfaceType) {
         }
     }
 
-    /// Composites the source surface onto this surface using the Porter-Duff
-    /// src-over operation at the destination. Any parts of the source outside
-    /// of the destination are ignored.
-    pub fn srcOver(dst: *Surface, src: *const Surface, dst_x: i32, dst_y: i32) void {
-        return switch (dst.*) {
-            inline else => |*s| s.srcOver(src, dst_x, dst_y),
-        };
-    }
-
-    /// Composites the source surface onto this surface using the Porter-Duff
-    /// dst-in operation at the destination. Any parts of the source outside
-    /// of the destination are ignored.
-    pub fn dstIn(dst: *Surface, src: *const Surface, dst_x: i32, dst_y: i32) void {
-        return switch (dst.*) {
-            inline else => |*s| s.dstIn(src, dst_x, dst_y),
-        };
+    /// Runs the single compositor operation described by `operator` with the
+    /// supplied `dst` and `src` at `(dst_x, dst_y)`. Any parts of the source
+    /// outside of the destination are ignored.
+    pub fn composite(
+        dst: *Surface,
+        src: *const Surface,
+        operator: compositor.Operator,
+        dst_x: i32,
+        dst_y: i32,
+    ) void {
+        compositor.SurfaceCompositor.run(
+            dst,
+            dst_x,
+            dst_y,
+            1,
+            .{.{ .operator = operator, .src = .{ .surface = src } }},
+        );
     }
 
     /// Gets the width of the surface.
@@ -246,6 +249,20 @@ pub const Surface = union(SurfaceType) {
         };
     }
 
+    /// Returns the range of pixels starting at `(x, y)` and proceeding for
+    /// `len`, as a pixel stride.
+    ///
+    /// Out-of-range start co-ordinates return an empty stride.
+    ///
+    /// `len` is unbounded and will wrap if going past the x-boundary of the
+    /// surface. Going past the actual length of the buffer is safety-checked
+    /// undefined behavior.
+    pub fn getStride(self: Surface, x: i32, y: i32, len: usize) pixel.Stride {
+        return switch (self) {
+            inline else => |s| s.getStride(x, y, len),
+        };
+    }
+
     /// Puts a single pixel at the x and y co-ordinates. This is a no-op if the
     /// co-ordinates are out of range.
     pub fn putPixel(self: *Surface, x: i32, y: i32, px: pixel.Pixel) void {
@@ -254,10 +271,36 @@ pub const Surface = union(SurfaceType) {
         };
     }
 
+    /// Puts the supplied stride at `(x, y)`, proceeding for its full length.
+    ///
+    /// Out-of-range start co-ordinates cause a no-op.
+    ///
+    /// It's expected that src will fit; overruns are safety-checked undefined
+    /// behavior.
+    pub fn putStride(self: *Surface, x: i32, y: i32, src: pixel.Stride) void {
+        return switch (self.*) {
+            inline else => |*s| s.putStride(x, y, src),
+        };
+    }
+
     /// Replaces the surface with the supplied pixel.
     pub fn paintPixel(self: *Surface, px: pixel.Pixel) void {
         return switch (self.*) {
             inline else => |*s| s.paintPixel(px),
+        };
+    }
+
+    /// Copies a single pixel to the range starting at `(x, y)` and proceeding
+    /// for `len`.
+    ///
+    /// Out-of-range start co-ordinates cause a no-op.
+    ///
+    /// `len` is unbounded and will wrap if going past the x-boundary of the
+    /// surface. Going past the actual length of the buffer is safety-checked
+    /// undefined behavior.
+    pub fn paintStride(self: *Surface, x: i32, y: i32, len: usize, px: pixel.Pixel) void {
+        return switch (self.*) {
+            inline else => |*s| s.paintStride(x, y, len, px),
         };
     }
 };
@@ -378,66 +421,6 @@ pub fn ImageSurface(comptime T: type) type {
             }
         }
 
-        /// Composites the source surface onto this surface using the
-        /// Porter-Duff src-over operation at the destination. Any parts of the
-        /// source outside of the destination are ignored.
-        pub fn srcOver(
-            dst: *ImageSurface(T),
-            src: *const Surface,
-            dst_x: i32,
-            dst_y: i32,
-        ) void {
-            return dst.composite(src, T.srcOver, dst_x, dst_y);
-        }
-
-        /// Composites the source surface onto this surface using the
-        /// Porter-Duff dst-in operation at the destination. Any parts of the
-        /// source outside of the destination are ignored.
-        pub fn dstIn(
-            dst: *ImageSurface(T),
-            src: *const Surface,
-            dst_x: i32,
-            dst_y: i32,
-        ) void {
-            return dst.composite(src, T.dstIn, dst_x, dst_y);
-        }
-
-        fn composite(
-            dst: *ImageSurface(T),
-            src: *const Surface,
-            op: fn (T, pixel.Pixel) T,
-            dst_x: i32,
-            dst_y: i32,
-        ) void {
-            if (dst_x >= dst.width or dst_y >= dst.height) return;
-
-            const src_start_y: i32 = if (dst_y < 0) @intCast(@abs(dst_y)) else 0;
-            const src_start_x: i32 = if (dst_x < 0) @intCast(@abs(dst_x)) else 0;
-
-            const height = if (src.getHeight() + dst_y > dst.height)
-                dst.height - dst_y
-            else
-                src.getHeight();
-            const width = if (src.getWidth() + dst_x > dst.width)
-                dst.width - dst_x
-            else
-                src.getWidth();
-
-            var src_y = src_start_y;
-            while (src_y < height) : (src_y += 1) {
-                var src_x = src_start_x;
-                while (src_x < width) : (src_x += 1) {
-                    const dst_put_x = src_x + dst_x;
-                    const dst_put_y = src_y + dst_y;
-                    const dst_idx: usize = @intCast(dst.width * dst_put_y + dst_put_x);
-                    if (src.getPixel(@intCast(src_x), @intCast(src_y))) |src_px| {
-                        const dst_px = dst.buf[dst_idx];
-                        dst.buf[dst_idx] = op(dst_px, src_px);
-                    }
-                }
-            }
-        }
-
         /// Returns a `Surface` interface for this surface.
         pub fn asSurfaceInterface(self: ImageSurface(T)) Surface {
             return switch (T.format) {
@@ -455,16 +438,58 @@ pub fn ImageSurface(comptime T: type) type {
             return self.buf[@intCast(self.width * y + x)].asPixel();
         }
 
+        /// Returns the range of pixels starting at `(x, y)` and proceeding for
+        /// `len`, as a pixel stride.
+        ///
+        /// Out-of-range start co-ordinates return an empty stride.
+        ///
+        /// `len` is unbounded and will wrap if going past the x-boundary of
+        /// the surface. Going past the actual length of the buffer is
+        /// safety-checked undefined behavior.
+        pub fn getStride(self: *const ImageSurface(T), x: i32, y: i32, len: usize) pixel.Stride {
+            if (x < 0 or y < 0 or x >= self.width or y >= self.height) {
+                return @unionInit(pixel.Stride, @tagName(T.format), &.{});
+            }
+            const start: usize = @intCast(self.width * y + x);
+            return @unionInit(pixel.Stride, @tagName(T.format), self.buf[start .. start + len]);
+        }
+
         /// Puts a single pixel at the `x` and `y` co-ordinates. No-ops if the
         /// pixel is out of range.
         pub fn putPixel(self: *ImageSurface(T), x: i32, y: i32, px: pixel.Pixel) void {
             if (x < 0 or y < 0 or x >= self.width or y >= self.height) return;
-            self.buf[@intCast(self.width * y + x)] = T.copySrc(px);
+            self.buf[@intCast(self.width * y + x)] = T.fromPixel(px);
+        }
+
+        /// Puts the supplied stride at `(x, y)`, proceeding for its full
+        /// length.
+        ///
+        /// Out-of-range start co-ordinates cause a no-op.
+        ///
+        /// It's expected that src will fit; overruns are
+        /// safety-checked undefined behavior.
+        pub fn putStride(self: *ImageSurface(T), x: i32, y: i32, src: pixel.Stride) void {
+            if (x < 0 or y < 0 or x >= self.width or y >= self.height) return;
+            self.getStride(x, y, src.pxLen()).copy(src);
         }
 
         /// Replaces the surface with the supplied pixel.
         pub fn paintPixel(self: *ImageSurface(T), px: pixel.Pixel) void {
-            @memset(self.buf, T.copySrc(px));
+            @memset(self.buf, T.fromPixel(px));
+        }
+
+        /// Copies a single pixel to the range starting at `(x, y)` and
+        /// proceeding for `len`.
+        ///
+        /// Out-of-range start co-ordinates cause a no-op.
+        ///
+        /// `len` is unbounded and will wrap if going past the x-boundary of
+        /// the surface. Going past the actual length of the buffer is
+        /// safety-checked undefined behavior.
+        pub fn paintStride(self: *ImageSurface(T), x: i32, y: i32, len: usize, px: pixel.Pixel) void {
+            if (x < 0 or y < 0 or x >= self.width or y >= self.height) return;
+            const start: usize = @intCast(self.width * y + x);
+            @memset(self.buf[start .. start + len], T.fromPixel(px));
         }
     };
 }
@@ -596,66 +621,6 @@ pub fn PackedImageSurface(comptime T: type) type {
             }
         }
 
-        /// Composites the source surface onto this surface using the
-        /// Porter-Duff src-over operation at the destination. Any parts of the
-        /// source outside of the destination are ignored.
-        pub fn srcOver(
-            dst: *PackedImageSurface(T),
-            src: *const Surface,
-            dst_x: i32,
-            dst_y: i32,
-        ) void {
-            return dst.composite(src, T.srcOver, dst_x, dst_y);
-        }
-
-        /// Composites the source surface onto this surface using the
-        /// Porter-Duff dst-in operation at the destination. Any parts of the
-        /// source outside of the destination are ignored.
-        pub fn dstIn(
-            dst: *PackedImageSurface(T),
-            src: *const Surface,
-            dst_x: i32,
-            dst_y: i32,
-        ) void {
-            return dst.composite(src, T.dstIn, dst_x, dst_y);
-        }
-
-        fn composite(
-            dst: *PackedImageSurface(T),
-            src: *const Surface,
-            op: fn (T, pixel.Pixel) T,
-            dst_x: i32,
-            dst_y: i32,
-        ) void {
-            if (dst_x >= dst.width or dst_y >= dst.height) return;
-
-            const src_start_y: i32 = if (dst_y < 0) @intCast(@abs(dst_y)) else 0;
-            const src_start_x: i32 = if (dst_x < 0) @intCast(@abs(dst_x)) else 0;
-
-            const height = if (src.getHeight() + dst_y > dst.height)
-                dst.height - dst_y
-            else
-                src.getHeight();
-            const width = if (src.getWidth() + dst_x > dst.width)
-                dst.width - dst_x
-            else
-                src.getWidth();
-
-            var src_y = src_start_y;
-            while (src_y < height) : (src_y += 1) {
-                var src_x = src_start_x;
-                while (src_x < width) : (src_x += 1) {
-                    const dst_put_x = src_x + dst_x;
-                    const dst_put_y = src_y + dst_y;
-                    const dst_idx: usize = @intCast(dst.width * dst_put_y + dst_put_x);
-                    if (src.getPixel(@intCast(src_x), @intCast(src_y))) |src_px| {
-                        const dst_px = dst._get(dst_idx);
-                        dst._set(dst_idx, op(dst_px, src_px));
-                    }
-                }
-            }
-        }
-
         /// Returns a `Surface` interface for this surface.
         pub fn asSurfaceInterface(self: PackedImageSurface(T)) Surface {
             return switch (T.format) {
@@ -673,16 +638,100 @@ pub fn PackedImageSurface(comptime T: type) type {
             return self._get(@intCast(self.width * y + x)).asPixel();
         }
 
+        /// Returns the range of pixels starting at `(x, y)` and proceeding for
+        /// `len`, as a pixel stride.
+        ///
+        /// `len` is unbounded and will wrap if going past the x-boundary of
+        /// the surface. Going past the actual length of the buffer, or
+        /// providing negative co-ordinates, is safety-checked undefined
+        /// behavior.
+        pub fn getStride(self: *const PackedImageSurface(T), x: i32, y: i32, len: usize) pixel.Stride {
+            if (x < 0 or y < 0 or x >= self.width or y >= self.height) {
+                return @unionInit(pixel.Stride, @tagName(T.format), .{
+                    .buf = &.{},
+                    .px_offset = 0,
+                    .px_len = 0,
+                });
+            }
+            const scale = 8 / @bitSizeOf(T);
+            const px_start: usize = @intCast(self.width * y + x);
+            const px_offset = px_start % scale;
+            const slice_start = px_start / scale;
+            const slice_len = ((len + px_offset) * @bitSizeOf(T) + 7) / 8;
+            return @unionInit(pixel.Stride, @tagName(T.format), .{
+                .buf = self.buf[slice_start .. slice_start + slice_len],
+                .px_offset = px_offset,
+                .px_len = len,
+            });
+        }
+
         /// Puts a single pixel at the `x` and `y` co-ordinates. No-ops if the
         /// pixel is out of range.
         pub fn putPixel(self: *PackedImageSurface(T), x: i32, y: i32, px: pixel.Pixel) void {
             if (x < 0 or y < 0 or x >= self.width or y >= self.height) return;
-            self._set(@intCast(self.width * y + x), T.copySrc(px));
+            self._set(@intCast(self.width * y + x), T.fromPixel(px));
+        }
+
+        /// Puts the supplied stride at `(x, y)`, proceeding for its full
+        /// length.
+        ///
+        /// Out-of-range start co-ordinates cause a no-op.
+        ///
+        /// It's expected that src will fit; overruns are safety-checked
+        /// undefined behavior.
+        pub fn putStride(self: *PackedImageSurface(T), x: i32, y: i32, src: pixel.Stride) void {
+            if (x < 0 or y < 0 or x >= self.width or y >= self.height) return;
+            self.getStride(x, y, src.pxLen()).copy(src);
         }
 
         /// Replaces the surface with the supplied pixel.
         pub fn paintPixel(self: *PackedImageSurface(T), px: pixel.Pixel) void {
-            _paintPixel(self.buf, T.copySrc(px));
+            _paintPixel(self.buf, T.fromPixel(px));
+        }
+
+        /// Copies a single pixel to the range starting at `(x, y)` and
+        /// proceeding for `len`.
+        ///
+        /// Out-of-range start co-ordinates cause a no-op.
+        ///
+        /// `len` is unbounded and will wrap if going past the x-boundary of
+        /// the surface. Going past the actual length of the buffer is
+        /// safety-checked undefined behavior.
+        pub fn paintStride(
+            self: *PackedImageSurface(T),
+            x: i32,
+            y: i32,
+            len: usize,
+            px: pixel.Pixel,
+        ) void {
+            if (x < 0 or y < 0 or x >= self.width or y >= self.height) return;
+            // Because we are doing a partial paint here, we need to be a bit
+            // more careful than we would be with paintPixel. We can do the
+            // majority still with our internal _paintPixel routine, but we
+            // need to slice off the contiguous part of memory to do so.
+            //
+            // We've already properly aligned our buffer, so we can check the
+            // start and end to make sure they're evenly divisible against our
+            // bit size. The remainders are the leftovers we need to
+            // individually set, if they exist.
+            const src_px = T.fromPixel(px);
+            const scale = 8 / @bitSizeOf(T);
+            const start: usize = @intCast(self.width * y + x);
+            const end = (start + len);
+            const slice_start: usize = start / scale;
+            const slice_end: usize = end / scale;
+            if (slice_start >= slice_end) {
+                // There's nothing we can memset, just set the range individually.
+                for (start..end) |idx| self._set(idx, src_px);
+                return;
+            }
+            const start_rem = start % scale;
+            const slice_offset = @intFromBool(start_rem > 0);
+            // Set our contiguous range
+            _paintPixel(self.buf[slice_start + slice_offset .. slice_end], src_px);
+            // Set the ends
+            for (start..start + (scale - start_rem)) |idx| self._set(idx, src_px);
+            for (end - end % scale..end) |idx| self._set(idx, src_px);
         }
 
         fn _get(self: *const PackedImageSurface(T), index: usize) T {
@@ -714,7 +763,7 @@ pub fn PackedImageSurface(comptime T: type) type {
             // will end up with even copies of the smaller-width integer since
             // we fill the whole byte, so the order of where it ends up in the
             // intCast should not matter.
-            if (meta.eql(px, std.mem.zeroes(T))) {
+            if (meta.eql(px, mem.zeroes(T))) {
                 // Short-circuit to writing zeroes if the pixel we're setting is zero
                 @memset(buf, 0);
                 return;
@@ -745,7 +794,7 @@ test "Surface interface" {
         inline for (@typeInfo(SurfaceType).Enum.fields) |f| {
             const surface_type: SurfaceType = @enumFromInt(f.value);
             const pixel_type = surface_type.toPixelType();
-            const pix = pixel_type.copySrc(rgba.asPixel()).asPixel();
+            const pix = pixel_type.fromPixel(rgba.asPixel()).asPixel();
 
             var sfc_if = try Surface.init(surface_type, testing.allocator, 1, 1);
             defer sfc_if.deinit(testing.allocator);
@@ -766,7 +815,7 @@ test "Surface interface" {
         inline for (@typeInfo(SurfaceType).Enum.fields) |f| {
             const surface_type: SurfaceType = @enumFromInt(f.value);
             const pixel_type = surface_type.toPixelType();
-            const pix = pixel_type.copySrc(rgba.asPixel()).asPixel();
+            const pix = pixel_type.fromPixel(rgba.asPixel()).asPixel();
 
             var sfc_if = try Surface.initPixel(pix, testing.allocator, 1, 1);
             defer sfc_if.deinit(testing.allocator);
@@ -785,7 +834,7 @@ test "Surface interface" {
             const surface_type: SurfaceType = @enumFromInt(f.value);
             const pixel_type = surface_type.toPixelType();
             const buffer_type = surface_type.toBufferType();
-            const pix = pixel_type.copySrc(rgba.asPixel()).asPixel();
+            const pix = pixel_type.fromPixel(rgba.asPixel()).asPixel();
 
             var buf: [1]buffer_type = undefined;
             var sfc_if = Surface.initBuffer(surface_type, null, &buf, 1, 1);
@@ -956,6 +1005,64 @@ test "PackedImageSurface, alpha4" {
         try testing.expectEqual(1, sfc.height);
         try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 7 } }, sfc.getPixel(0, 0));
     }
+
+    {
+        // getStride
+        var sfc = try PackedImageSurface(pixel.Alpha4).init(testing.allocator, 3, 3, null);
+        defer sfc.deinit(testing.allocator);
+
+        sfc.putPixel(0, 1, .{ .alpha4 = .{ .a = 15 } });
+        const stride = sfc.getStride(0, 1, 4);
+
+        try testing.expectEqual(3, stride.alpha4.buf.len);
+        try testing.expectEqual(0xF0, stride.alpha4.buf[0]);
+        try testing.expectEqual(0x00, stride.alpha4.buf[1]);
+        try testing.expectEqual(0x00, stride.alpha4.buf[2]);
+        try testing.expectEqual(1, stride.alpha4.px_offset);
+        try testing.expectEqual(4, stride.alpha4.px_len);
+    }
+
+    {
+        // paintStride, testing contiguous ranges. Unlike paintPixel, we want to
+        // make sure only a very specific range of pixels were touched.
+        var sfc = try PackedImageSurface(pixel.Alpha4).init(testing.allocator, 3, 3, null);
+        defer sfc.deinit(testing.allocator);
+
+        sfc.paintStride(1, 0, 6, .{ .alpha4 = .{ .a = 15 } });
+
+        try testing.expectEqual(5, sfc.buf.len);
+        try testing.expectEqual(0xF0, sfc.buf[0]);
+        try testing.expectEqual(0xFF, sfc.buf[1]);
+        try testing.expectEqual(0xFF, sfc.buf[2]);
+        try testing.expectEqual(0x0F, sfc.buf[3]);
+        try testing.expectEqual(0x00, sfc.buf[4]);
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 0 } }, sfc.getPixel(0, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 15 } }, sfc.getPixel(1, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 15 } }, sfc.getPixel(2, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 15 } }, sfc.getPixel(0, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 15 } }, sfc.getPixel(1, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 15 } }, sfc.getPixel(2, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 15 } }, sfc.getPixel(0, 2));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 0 } }, sfc.getPixel(1, 2));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 0 } }, sfc.getPixel(2, 2));
+
+        sfc.paintPixel(.{ .alpha4 = .{ .a = 0 } });
+        sfc.paintStride(0, 1, 6, .{ .alpha4 = .{ .a = 15 } });
+        try testing.expectEqual(0x00, sfc.buf[0]);
+        try testing.expectEqual(0xF0, sfc.buf[1]);
+        try testing.expectEqual(0xFF, sfc.buf[2]);
+        try testing.expectEqual(0xFF, sfc.buf[3]);
+        try testing.expectEqual(0x0F, sfc.buf[4]);
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 0 } }, sfc.getPixel(0, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 0 } }, sfc.getPixel(1, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 0 } }, sfc.getPixel(2, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 15 } }, sfc.getPixel(0, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 15 } }, sfc.getPixel(1, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 15 } }, sfc.getPixel(2, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 15 } }, sfc.getPixel(0, 2));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 15 } }, sfc.getPixel(1, 2));
+        try testing.expectEqual(pixel.Pixel{ .alpha4 = .{ .a = 15 } }, sfc.getPixel(2, 2));
+    }
 }
 
 test "PackedImageSurface, alpha2" {
@@ -1031,6 +1138,60 @@ test "PackedImageSurface, alpha2" {
         try testing.expectEqual(1, sfc.width);
         try testing.expectEqual(1, sfc.height);
         try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 2 } }, sfc.getPixel(0, 0));
+    }
+
+    {
+        // getStride
+        var sfc = try PackedImageSurface(pixel.Alpha2).init(testing.allocator, 3, 3, null);
+        defer sfc.deinit(testing.allocator);
+
+        sfc.putPixel(0, 1, .{ .alpha2 = .{ .a = 2 } });
+        const stride = sfc.getStride(0, 1, 6);
+
+        try testing.expectEqual(3, stride.alpha2.buf.len);
+        try testing.expectEqual(0x80, stride.alpha2.buf[0]);
+        try testing.expectEqual(0x00, stride.alpha2.buf[1]);
+        try testing.expectEqual(0x00, stride.alpha2.buf[2]);
+        try testing.expectEqual(3, stride.alpha2.px_offset);
+        try testing.expectEqual(6, stride.alpha2.px_len);
+    }
+
+    {
+        // paintStride, testing contiguous ranges. Unlike paintPixel, we want to
+        // make sure only a very specific range of pixels were touched.
+        var sfc = try PackedImageSurface(pixel.Alpha2).init(testing.allocator, 3, 3, null);
+        defer sfc.deinit(testing.allocator);
+
+        sfc.paintStride(1, 0, 6, .{ .alpha2 = .{ .a = 3 } });
+
+        try testing.expectEqual(3, sfc.buf.len);
+        try testing.expectEqual(0xFC, sfc.buf[0]);
+        try testing.expectEqual(0x3F, sfc.buf[1]);
+        try testing.expectEqual(0x00, sfc.buf[2]);
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 0 } }, sfc.getPixel(0, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 3 } }, sfc.getPixel(1, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 3 } }, sfc.getPixel(2, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 3 } }, sfc.getPixel(0, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 3 } }, sfc.getPixel(1, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 3 } }, sfc.getPixel(2, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 3 } }, sfc.getPixel(0, 2));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 0 } }, sfc.getPixel(1, 2));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 0 } }, sfc.getPixel(2, 2));
+
+        sfc.paintPixel(.{ .alpha2 = .{ .a = 0 } });
+        sfc.paintStride(0, 1, 6, .{ .alpha2 = .{ .a = 3 } });
+        try testing.expectEqual(0xC0, sfc.buf[0]);
+        try testing.expectEqual(0xFF, sfc.buf[1]);
+        try testing.expectEqual(0x03, sfc.buf[2]);
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 0 } }, sfc.getPixel(0, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 0 } }, sfc.getPixel(1, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 0 } }, sfc.getPixel(2, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 3 } }, sfc.getPixel(0, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 3 } }, sfc.getPixel(1, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 3 } }, sfc.getPixel(2, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 3 } }, sfc.getPixel(0, 2));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 3 } }, sfc.getPixel(1, 2));
+        try testing.expectEqual(pixel.Pixel{ .alpha2 = .{ .a = 3 } }, sfc.getPixel(2, 2));
     }
 }
 
@@ -1120,5 +1281,56 @@ test "PackedImageSurface, alpha1" {
         try testing.expectEqual(1, sfc.width);
         try testing.expectEqual(1, sfc.height);
         try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 0 } }, sfc.getPixel(0, 0));
+    }
+
+    {
+        // getStride
+        var sfc = try PackedImageSurface(pixel.Alpha1).init(testing.allocator, 3, 3, null);
+        defer sfc.deinit(testing.allocator);
+
+        sfc.putPixel(0, 2, .{ .alpha1 = .{ .a = 1 } });
+        const stride = sfc.getStride(0, 2, 3);
+
+        try testing.expectEqual(2, stride.alpha1.buf.len);
+        try testing.expectEqual(0x40, stride.alpha1.buf[0]);
+        try testing.expectEqual(0x00, stride.alpha1.buf[1]);
+        try testing.expectEqual(6, stride.alpha1.px_offset);
+        try testing.expectEqual(3, stride.alpha1.px_len);
+    }
+
+    {
+        // paintStride, testing contiguous ranges. Unlike paintPixel, we want to
+        // make sure only a very specific range of pixels were touched.
+        var sfc = try PackedImageSurface(pixel.Alpha1).init(testing.allocator, 3, 3, null);
+        defer sfc.deinit(testing.allocator);
+
+        sfc.paintStride(1, 0, 6, .{ .alpha1 = .{ .a = 1 } });
+
+        try testing.expectEqual(2, sfc.buf.len);
+        try testing.expectEqual(0b1111110, sfc.buf[0]);
+        try testing.expectEqual(0, sfc.buf[1]);
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 0 } }, sfc.getPixel(0, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 1 } }, sfc.getPixel(1, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 1 } }, sfc.getPixel(2, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 1 } }, sfc.getPixel(0, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 1 } }, sfc.getPixel(1, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 1 } }, sfc.getPixel(2, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 1 } }, sfc.getPixel(0, 2));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 0 } }, sfc.getPixel(1, 2));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 0 } }, sfc.getPixel(2, 2));
+
+        sfc.paintPixel(.{ .alpha1 = .{ .a = 0 } });
+        sfc.paintStride(0, 1, 6, .{ .alpha1 = .{ .a = 1 } });
+        try testing.expectEqual(0b11111000, sfc.buf[0]);
+        try testing.expectEqual(1, sfc.buf[1]);
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 0 } }, sfc.getPixel(0, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 0 } }, sfc.getPixel(1, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 0 } }, sfc.getPixel(2, 0));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 1 } }, sfc.getPixel(0, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 1 } }, sfc.getPixel(1, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 1 } }, sfc.getPixel(2, 1));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 1 } }, sfc.getPixel(0, 2));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 1 } }, sfc.getPixel(1, 2));
+        try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 1 } }, sfc.getPixel(2, 2));
     }
 }

--- a/src/z2d.zig
+++ b/src/z2d.zig
@@ -48,6 +48,10 @@
 //! * `surface` - The package `Surface` resides in, exposes additional types
 //! and documentation.
 //!
+//! * `compositor` - Provides access to the compositor, both the short-hand
+//! functions that are aliased within the `pixel` and `surface` packages, and
+//! also to lower-level multi-step compositor functions.
+//!
 //! * `painter` - Contains the unmanaged painter functions for filling and
 //! stroking.
 //!
@@ -55,7 +59,8 @@
 //! and documentation.
 //!
 //! * `pixel` - Contains the concrete pixel types wrapped by `Pixel`, including
-//! utility functions for various formats.
+//! utility functions for various formats, and abstractions for lower-level
+//! pixel data access (strides).
 //!
 //! * `options` - Documents option enumerations used in various parts of the
 //! library.
@@ -65,6 +70,7 @@
 pub const surface = @import("surface.zig");
 pub const pattern = @import("pattern.zig");
 pub const painter = @import("painter.zig");
+pub const compositor = @import("compositor.zig");
 pub const pixel = @import("pixel.zig");
 pub const options = @import("options.zig");
 pub const png_exporter = @import("export_png.zig");


### PR DESCRIPTION
This commit introduces some major changes to the compositor. This is ahead of work that will be happening to introduce extra compositor operations, including over a dozen or so blend modes - this makes the current implement-everything-with-boilerplate approach to composition operations untenable.

This requirement has allowed us to do a review of how we are doing the compositor, which has actually allowed us to greatly improve performance - approximately 20% non-AA, and **over 40% on default AA** for fill on RGBA surfaces (tested on a Zen3+ CPU w/AVX2). This latter case (AA on RGBA or RGB) also no longer requires an intermediary surface for its in (previously dstIn) operator, adding RAM savings onto the optimizations as well.

The summary of the changes:

* A new "compositor" package has been added - this contains all of our code to do composition operations, including a new multi-step "pipeline" that allows operations to be layered on top of each other and the ability to customize destinations and sources for each step. Note that this raw, multi-step functionality is lower-level and is not necessarily recommended for everyone, and not all combinations of dst/src will make sense (e.g., overriding dst in a way that ultimately does not get you changed pixels). Composition is vectorized with a minimum of 8 elements per vector and more if a larger SIMD length is detected.

* All individual composition operator functions have been removed from Surface and Pixel, and their underlying types - they have been replaced with a "composite" function that takes an operator (e.g., "in" for "dstIn" and "over" for "srcOver") and does the same thing. These alias to the appropriate lower-level operation in the compositor package.

* A new feature - pixel strides - has been introduced in the "pixel" package. The stride type ("Stride") allows for the fetching of slices representing contiguous regions of pixel memory. Normally, this will be lines, but we keep this definition loose by design to allow for smaller (or even larger) units, e.g., restricting to vector lengths or possibly even operating on the whole of a buffer. Safety is much more relaxed on these operations than individual pixel functions, so care is advised to avoid undefined behavior.

* The same "composite" function available on Surface and Pixel is also available to strides.

* "fromPixel" functions in each major pixel type have been removed - "fromPixel" is now what "copySrc" used to be and will convert from other pixel types in a way that tries to retain as much information from the other type as possible. For the older strict functionality, consumers can just test off of the union tag.

* Finally, there have been minor adjustments, namely to try and either not be wasteful on integer space (e.g., we've turned down the integer size on "average" for all major pixel types and "multiply"/"demultiply" for RGBA to u16) or make things more "Zig", like using inline prongs on our union switches. inline has also been removed from a lot of things to avoid unnecessary inlining.