### PR TITLE
gradient: unify all gradient types

### DIFF
--- a/spec/059_stroke_star_gradient.zig
+++ b/spec/059_stroke_star_gradient.zig
@@ -24,18 +24,17 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     const x_scale = 3;
     const y_scale = 5;
 
-    var gradient = z2d.gradient.Linear.init(
-        0 + margin * 3,
-        height / 2,
-        width - margin * 3,
-        height / 2,
-        .linear_rgb,
-    );
+    var gradient = z2d.Gradient.init(.{ .type = .{ .linear = .{
+        .x0 = 0 + margin * 3,
+        .y0 = height / 2,
+        .x1 = width - margin * 3,
+        .y1 = height / 2,
+    } } });
     defer gradient.deinit(alloc);
-    try gradient.stops.add(alloc, 0, .{ .rgb = .{ 1, 0, 0 } });
-    try gradient.stops.add(alloc, 0.5, .{ .rgb = .{ 0, 1, 0 } });
-    try gradient.stops.add(alloc, 1, .{ .rgb = .{ 0, 0, 1 } });
-    context.setSource(gradient.asPatternInterface());
+    try gradient.addStop(alloc, 0, .{ .rgb = .{ 1, 0, 0 } });
+    try gradient.addStop(alloc, 0.5, .{ .rgb = .{ 0, 1, 0 } });
+    try gradient.addStop(alloc, 1, .{ .rgb = .{ 0, 0, 1 } });
+    context.setSource(gradient.asPattern());
 
     // With all 5 points numbered 1-5 clockwise, we draw odds first (1, 3, 5),
     // then evens (4, 2), with the close connecting 4 and 1.

--- a/spec/060_ghostty_logo.zig
+++ b/spec/060_ghostty_logo.zig
@@ -45,12 +45,17 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     defer context.deinit();
     context.setAntiAliasingMode(aa_mode);
 
-    var gradient = z2d.gradient.Linear.init(0, 49, 82, 49, .linear_rgb);
+    var gradient = z2d.Gradient.init(.{ .type = .{ .linear = .{
+        .x0 = 0,
+        .y0 = 49,
+        .x1 = 82,
+        .y1 = 49,
+    } } });
     defer gradient.deinit(alloc);
-    try gradient.stops.add(alloc, 0, .{ .rgb = .{ 1, 0, 0 } });
-    try gradient.stops.add(alloc, 0.5, .{ .rgb = .{ 0, 1, 0 } });
-    try gradient.stops.add(alloc, 1, .{ .rgb = .{ 0, 0, 1 } });
-    context.setSource(gradient.asPatternInterface());
+    try gradient.addStop(alloc, 0, .{ .rgb = .{ 1, 0, 0 } });
+    try gradient.addStop(alloc, 0.5, .{ .rgb = .{ 0, 1, 0 } });
+    try gradient.addStop(alloc, 1, .{ .rgb = .{ 0, 0, 1 } });
+    context.setSource(gradient.asPattern());
 
     try context.moveTo(62.186, 97.000);
     try context.curveTo(58.431, 97.000, 54.746, 95.875, 51.637, 93.800);
@@ -92,7 +97,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     try context.closePath();
     try context.fill();
 
-    context.setSource(gradient.asPatternInterface());
+    context.setSource(gradient.asPattern());
     context.resetPath();
     try context.moveTo(72.736, 41.088);
     try context.lineTo(72.736, 77.849);

--- a/spec/061_linear_gradient.zig
+++ b/spec/061_linear_gradient.zig
@@ -54,20 +54,21 @@ fn draw(
     linear_y1: f64,
 ) void {
     var stop_buffer: [3]z2d.gradient.Stop = undefined;
-    var gradient = z2d.gradient.Linear.initBuffer(
-        linear_x0,
-        linear_y0,
-        linear_x1,
-        linear_y1,
-        &stop_buffer,
-        .linear_rgb,
-    );
-    gradient.stops.addAssumeCapacity(0, .{ .rgb = .{ 1, 0, 0 } });
-    gradient.stops.addAssumeCapacity(0.5, .{ .rgb = .{ 0, 1, 0 } });
-    gradient.stops.addAssumeCapacity(1, .{ .rgb = .{ 0, 0, 1 } });
+    var gradient = z2d.Gradient.init(.{
+        .type = .{ .linear = .{
+            .x0 = linear_x0,
+            .y0 = linear_y0,
+            .x1 = linear_x1,
+            .y1 = linear_y1,
+        } },
+        .stops = &stop_buffer,
+    });
+    gradient.addStopAssumeCapacity(0, .{ .rgb = .{ 1, 0, 0 } });
+    gradient.addStopAssumeCapacity(0.5, .{ .rgb = .{ 0, 1, 0 } });
+    gradient.addStopAssumeCapacity(1, .{ .rgb = .{ 0, 0, 1 } });
     z2d.compositor.SurfaceCompositor.run(scratch_sfc, 0, 0, 1, .{.{
         .operator = .over,
-        .src = .{ .gradient = .{ .linear = &gradient } },
+        .src = .{ .gradient = &gradient },
     }});
     dst_sfc.composite(scratch_sfc, .over, sfc_x, sfc_y);
 }

--- a/spec/062_hsl_gradient.zig
+++ b/spec/062_hsl_gradient.zig
@@ -109,19 +109,21 @@ fn draw(
     var scratch_sfc = try z2d.Surface.init(.image_surface_rgba, alloc, width, height);
     defer scratch_sfc.deinit(alloc);
     var stop_buffer: [2]z2d.gradient.Stop = undefined;
-    var gradient = z2d.gradient.Linear.initBuffer(
-        linear_x0,
-        linear_y0,
-        linear_x1,
-        linear_y1,
-        &stop_buffer,
-        .{ .hsl = .shorter },
-    );
-    gradient.stops.addAssumeCapacity(0, c0);
-    gradient.stops.addAssumeCapacity(1, c1);
+    var gradient = z2d.Gradient.init(.{
+        .type = .{ .linear = .{
+            .x0 = linear_x0,
+            .y0 = linear_y0,
+            .x1 = linear_x1,
+            .y1 = linear_y1,
+        } },
+        .stops = &stop_buffer,
+        .method = .{ .hsl = .shorter },
+    });
+    gradient.addStopAssumeCapacity(0, c0);
+    gradient.addStopAssumeCapacity(1, c1);
     z2d.compositor.SurfaceCompositor.run(&scratch_sfc, 0, 0, 1, .{.{
         .operator = .over,
-        .src = .{ .gradient = .{ .linear = &gradient } },
+        .src = .{ .gradient = &gradient },
     }});
     dst_sfc.composite(&scratch_sfc, .over, sfc_x, sfc_y);
 }

--- a/spec/063_radial_gradient.zig
+++ b/spec/063_radial_gradient.zig
@@ -136,22 +136,23 @@ fn draw(
     var scratch_sfc = try z2d.Surface.init(.image_surface_rgba, alloc, 100, 100);
     defer scratch_sfc.deinit(alloc);
     var stop_buffer: [3]z2d.gradient.Stop = undefined;
-    var gradient = z2d.gradient.Radial.initBuffer(
-        inner_x,
-        inner_y,
-        inner_radius,
-        outer_x,
-        outer_y,
-        outer_radius,
-        &stop_buffer,
-        .linear_rgb,
-    );
-    gradient.stops.addAssumeCapacity(0, .{ .rgb = .{ 1, 0, 0 } });
-    gradient.stops.addAssumeCapacity(0.5, .{ .rgb = .{ 0, 1, 0 } });
-    gradient.stops.addAssumeCapacity(1, .{ .rgb = .{ 0, 0, 1 } });
+    var gradient = z2d.Gradient.init(.{
+        .type = .{ .radial = .{
+            .inner_x = inner_x,
+            .inner_y = inner_y,
+            .inner_radius = inner_radius,
+            .outer_x = outer_x,
+            .outer_y = outer_y,
+            .outer_radius = outer_radius,
+        } },
+        .stops = &stop_buffer,
+    });
+    gradient.addStopAssumeCapacity(0, .{ .rgb = .{ 1, 0, 0 } });
+    gradient.addStopAssumeCapacity(0.5, .{ .rgb = .{ 0, 1, 0 } });
+    gradient.addStopAssumeCapacity(1, .{ .rgb = .{ 0, 0, 1 } });
     z2d.compositor.SurfaceCompositor.run(&scratch_sfc, 0, 0, 1, .{.{
         .operator = .over,
-        .src = .{ .gradient = .{ .radial = &gradient } },
+        .src = .{ .gradient = &gradient },
     }});
     dst_sfc.composite(&scratch_sfc, .over, sfc_x, sfc_y);
 }

--- a/spec/064_radial_source.zig
+++ b/spec/064_radial_source.zig
@@ -15,23 +15,24 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     const height = 100;
     var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
     var stop_buffer: [3]z2d.gradient.Stop = undefined;
-    var gradient = z2d.gradient.Radial.initBuffer(
-        49,
-        49,
-        0,
-        49,
-        49,
-        50,
-        &stop_buffer,
-        .linear_rgb,
-    );
-    gradient.stops.addAssumeCapacity(0, .{ .rgb = .{ 1, 0, 0 } });
-    gradient.stops.addAssumeCapacity(0.5, .{ .rgb = .{ 0, 1, 0 } });
-    gradient.stops.addAssumeCapacity(1, .{ .rgb = .{ 0, 0, 1 } });
+    var gradient = z2d.Gradient.init(.{
+        .type = .{ .radial = .{
+            .inner_x = 49,
+            .inner_y = 49,
+            .inner_radius = 0,
+            .outer_x = 49,
+            .outer_y = 49,
+            .outer_radius = 50,
+        } },
+        .stops = &stop_buffer,
+    });
+    gradient.addStopAssumeCapacity(0, .{ .rgb = .{ 1, 0, 0 } });
+    gradient.addStopAssumeCapacity(0.5, .{ .rgb = .{ 0, 1, 0 } });
+    gradient.addStopAssumeCapacity(1, .{ .rgb = .{ 0, 0, 1 } });
     var context = try z2d.Context.init(alloc, &sfc);
     defer context.deinit();
     context.setAntiAliasingMode(aa_mode);
-    context.setSource(gradient.asPatternInterface());
+    context.setSource(gradient.asPattern());
     try context.moveTo(0, 0);
     try context.lineTo(100, 0);
     try context.lineTo(100, 100);

--- a/spec/065_conic_gradient.zig
+++ b/spec/065_conic_gradient.zig
@@ -43,18 +43,20 @@ fn draw(
     var scratch_sfc = try z2d.Surface.init(.image_surface_rgba, alloc, 100, 100);
     defer scratch_sfc.deinit(alloc);
     var stop_buffer: [2]z2d.gradient.Stop = undefined;
-    var gradient = z2d.gradient.Conic.initBuffer(
-        center_x,
-        center_y,
-        angle,
-        &stop_buffer,
-        .{ .hsl = .increasing },
-    );
-    gradient.stops.addAssumeCapacity(0, .{ .hsl = .{ 0, 1, 0.5 } });
-    gradient.stops.addAssumeCapacity(1, .{ .hsl = .{ 360, 1, 0.5 } });
+    var gradient = z2d.Gradient.init(.{
+        .type = .{ .conic = .{
+            .x = center_x,
+            .y = center_y,
+            .angle = angle,
+        } },
+        .stops = &stop_buffer,
+        .method = .{ .hsl = .increasing },
+    });
+    gradient.addStopAssumeCapacity(0, .{ .hsl = .{ 0, 1, 0.5 } });
+    gradient.addStopAssumeCapacity(1, .{ .hsl = .{ 360, 1, 0.5 } });
     z2d.compositor.SurfaceCompositor.run(&scratch_sfc, 0, 0, 1, .{.{
         .operator = .over,
-        .src = .{ .gradient = .{ .conic = &gradient } },
+        .src = .{ .gradient = &gradient },
     }});
     dst_sfc.composite(&scratch_sfc, .over, sfc_x, sfc_y);
 }

--- a/spec/066_conic_pie_gradient.zig
+++ b/spec/066_conic_pie_gradient.zig
@@ -25,23 +25,24 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     const height = 300;
     var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
     var stop_buffer: [6]z2d.gradient.Stop = undefined;
-    var gradient = z2d.gradient.Conic.initBuffer(
-        149,
-        149,
-        0,
-        &stop_buffer,
-        .linear_rgb,
-    );
-    gradient.stops.addAssumeCapacity(0, .{ .rgb = .{ 1, 0, 0 } });
-    gradient.stops.addAssumeCapacity(1.0 / 3.0, .{ .rgb = .{ 1, 0, 0 } });
-    gradient.stops.addAssumeCapacity(1.0 / 3.0 + 0.005, .{ .rgb = .{ 0, 1, 0 } });
-    gradient.stops.addAssumeCapacity(2.0 / 3.0, .{ .rgb = .{ 0, 1, 0 } });
-    gradient.stops.addAssumeCapacity(2.0 / 3.0 + 0.005, .{ .rgb = .{ 0, 0, 1 } });
-    gradient.stops.addAssumeCapacity(1, .{ .rgb = .{ 0, 0, 1 } });
+    var gradient = z2d.Gradient.init(.{
+        .type = .{ .conic = .{
+            .x = 149,
+            .y = 149,
+            .angle = 0,
+        } },
+        .stops = &stop_buffer,
+    });
+    gradient.addStopAssumeCapacity(0, .{ .rgb = .{ 1, 0, 0 } });
+    gradient.addStopAssumeCapacity(1.0 / 3.0, .{ .rgb = .{ 1, 0, 0 } });
+    gradient.addStopAssumeCapacity(1.0 / 3.0 + 0.005, .{ .rgb = .{ 0, 1, 0 } });
+    gradient.addStopAssumeCapacity(2.0 / 3.0, .{ .rgb = .{ 0, 1, 0 } });
+    gradient.addStopAssumeCapacity(2.0 / 3.0 + 0.005, .{ .rgb = .{ 0, 0, 1 } });
+    gradient.addStopAssumeCapacity(1, .{ .rgb = .{ 0, 0, 1 } });
     var context = try z2d.Context.init(alloc, &sfc);
     defer context.deinit();
     context.setAntiAliasingMode(aa_mode);
-    context.setSource(gradient.asPatternInterface());
+    context.setSource(gradient.asPattern());
     try context.arc(149, 149, 100, 0, math.pi * 2);
     try context.closePath();
     try context.fill();

--- a/spec/067_gradient_transforms.zig
+++ b/spec/067_gradient_transforms.zig
@@ -13,22 +13,21 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     const width = 200;
     const height = 200;
     var sfc = try z2d.Surface.init(.image_surface_rgb, alloc, width, height);
-    var linear = z2d.gradient.Linear.init(
-        0,
-        0,
-        50,
-        50,
-        .linear_rgb,
-    );
+    var linear = z2d.Gradient.init(.{ .type = .{ .linear = .{
+        .x0 = 0,
+        .y0 = 0,
+        .x1 = 50,
+        .y1 = 50,
+    } } });
     defer linear.deinit(alloc);
-    try linear.stops.add(alloc, 0, .{ .rgb = .{ 1, 0, 0 } });
-    try linear.stops.add(alloc, 0.5, .{ .rgb = .{ 0, 1, 0 } });
-    try linear.stops.add(alloc, 1, .{ .rgb = .{ 0, 0, 1 } });
+    try linear.addStop(alloc, 0, .{ .rgb = .{ 1, 0, 0 } });
+    try linear.addStop(alloc, 0.5, .{ .rgb = .{ 0, 1, 0 } });
+    try linear.addStop(alloc, 1, .{ .rgb = .{ 0, 0, 1 } });
     var context = try z2d.Context.init(alloc, &sfc);
     defer context.deinit();
     context.scale(2, 2);
     context.setAntiAliasingMode(aa_mode);
-    context.setSource(linear.asPatternInterface());
+    context.setSource(linear.asPattern());
     try context.moveTo(0, 0);
     try context.lineTo(50, 0);
     try context.lineTo(50, 50);
@@ -36,25 +35,26 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     try context.closePath();
     try context.fill();
 
-    var radial = z2d.gradient.Radial.init(
-        25,
-        50,
-        0,
-        25,
-        50,
-        50,
-        .linear_rgb,
-    );
+    var radial = z2d.Gradient.init(.{
+        .type = .{ .radial = .{
+            .inner_x = 25,
+            .inner_y = 50,
+            .inner_radius = 0,
+            .outer_x = 25,
+            .outer_y = 50,
+            .outer_radius = 50,
+        } },
+    });
     defer radial.deinit(alloc);
-    try radial.stops.add(alloc, 0, .{ .rgb = .{ 1, 0, 0 } });
-    try radial.stops.add(alloc, 0.5, .{ .rgb = .{ 0, 1, 0 } });
-    try radial.stops.add(alloc, 1, .{ .rgb = .{ 0, 0, 1 } });
+    try radial.addStop(alloc, 0, .{ .rgb = .{ 1, 0, 0 } });
+    try radial.addStop(alloc, 0.5, .{ .rgb = .{ 0, 1, 0 } });
+    try radial.addStop(alloc, 1, .{ .rgb = .{ 0, 0, 1 } });
     context.setIdentity();
     var skew = z2d.Transformation.identity;
     skew.by = 0.5;
     context.mul(skew);
     context.translate(100, 0);
-    context.setSource(radial.asPatternInterface());
+    context.setSource(radial.asPattern());
     context.setIdentity();
     context.translate(100, 0);
     context.resetPath();
@@ -65,19 +65,21 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     try context.closePath();
     try context.fill();
 
-    var conic = z2d.gradient.Conic.init(
-        50,
-        50,
-        0,
-        .{ .hsl = .increasing },
-    );
+    var conic = z2d.Gradient.init(.{
+        .type = .{ .conic = .{
+            .x = 50,
+            .y = 50,
+            .angle = 0,
+        } },
+        .method = .{ .hsl = .increasing },
+    });
     defer conic.deinit(alloc);
-    try conic.stops.add(alloc, 0, .{ .hsl = .{ 0, 1, 0.5 } });
-    try conic.stops.add(alloc, 1, .{ .hsl = .{ 360, 1, 0.5 } });
+    try conic.addStop(alloc, 0, .{ .hsl = .{ 0, 1, 0.5 } });
+    try conic.addStop(alloc, 1, .{ .hsl = .{ 360, 1, 0.5 } });
     context.setIdentity();
     context.scale(2, 1);
     context.translate(0, 100);
-    context.setSource(conic.asPatternInterface());
+    context.setSource(conic.asPattern());
     context.resetPath();
     try context.moveTo(0, 0);
     try context.lineTo(100, 0);

--- a/spec/069_gradient_dither_context.zig
+++ b/spec/069_gradient_dither_context.zig
@@ -16,20 +16,21 @@ pub const filename = "069_gradient_dither_context";
 
 pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Surface {
     var dst_sfc = try z2d.Surface.init(.image_surface_alpha4, alloc, 400, 150);
-    var gradient = z2d.gradient.Linear.init(
-        0,
-        25,
-        400,
-        25,
-        .linear_rgb,
-    );
+    var gradient = z2d.Gradient.init(.{
+        .type = .{ .linear = .{
+            .x0 = 0,
+            .y0 = 25,
+            .x1 = 400,
+            .y1 = 25,
+        } },
+    });
     defer gradient.deinit(alloc);
-    try gradient.stops.add(alloc, 0, .{ .rgba = .{ 0, 0, 0, 0 } });
-    try gradient.stops.add(alloc, 1, .{ .rgba = .{ 1, 1, 1, 1 } });
+    try gradient.addStop(alloc, 0, .{ .rgba = .{ 0, 0, 0, 0 } });
+    try gradient.addStop(alloc, 1, .{ .rgba = .{ 1, 1, 1, 1 } });
     var context = try z2d.Context.init(alloc, &dst_sfc);
     defer context.deinit();
     context.setAntiAliasingMode(aa_mode);
-    context.setSource(gradient.asPatternInterface());
+    context.setSource(gradient.asPattern());
     try context.moveTo(0, 0);
     try context.lineTo(400, 0);
     try context.lineTo(400, 50);
@@ -39,7 +40,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
 
     context.resetPath();
     context.translate(0, 50);
-    context.setSource(gradient.asPatternInterface());
+    context.setSource(gradient.asPattern());
     context.setDither(.bayer);
     try context.moveTo(0, 0);
     try context.lineTo(400, 0);
@@ -51,7 +52,7 @@ pub fn render(alloc: mem.Allocator, aa_mode: z2d.options.AntiAliasMode) !z2d.Sur
     context.resetPath();
     context.setIdentity();
     context.translate(0, 100);
-    context.setSource(gradient.asPatternInterface());
+    context.setSource(gradient.asPattern());
     context.setDither(.blue_noise);
     try context.moveTo(0, 0);
     try context.lineTo(400, 0);

--- a/src/Context.zig
+++ b/src/Context.zig
@@ -87,10 +87,7 @@ pub fn getDither(self: *Context) Dither {
 /// CTM is not invertible.
 pub fn setSource(self: *Context, source: Pattern) void {
     switch (source) {
-        inline .linear_gradient,
-        .radial_gradient,
-        .conic_gradient,
-        => |g| g.setTransformation(self.transformation) catch return,
+        .gradient => |g| g.setTransformation(self.transformation) catch return,
         else => {},
     }
     self.pattern = source;
@@ -510,9 +507,7 @@ fn wrapDither(self: *Context) Pattern {
                 .type = self.dither,
                 .source = switch (self.pattern) {
                     .opaque_pattern => |p| .{ .pixel = p.pixel },
-                    .linear_gradient => |g| .{ .gradient = .{ .linear = g } },
-                    .radial_gradient => |g| .{ .gradient = .{ .radial = g } },
-                    .conic_gradient => |g| .{ .gradient = .{ .conic = g } },
+                    .gradient => |g| .{ .gradient = g },
                     else => return self.pattern,
                 },
                 .scale = switch (self.surface.*) {

--- a/src/gradient.zig
+++ b/src/gradient.zig
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 //   Copyright © 2024 Chris Marchesi
 
+//! Contains types and utility functions for gradients.
+
 const std = @import("std");
 const debug = @import("std").debug;
 const math = @import("std").math;

--- a/src/gradient.zig
+++ b/src/gradient.zig
@@ -1142,6 +1142,58 @@ test "Stop.List.search, hard stops" {
     }, stops.search(1));
 }
 
+test "Linear.initBuffer" {
+    const name = "Linear.initBuffer";
+    var buf = [_]Stop{
+        .{
+            .idx = 0,
+            .color = Color.init(.{ .rgb = .{ 1, 0, 0 } }),
+            .offset = 0.5,
+        },
+    };
+    const cases = [_]struct {
+        name: []const u8,
+        expected: Linear,
+        x0: f64,
+        y0: f64,
+        x1: f64,
+        y1: f64,
+        buffer: []Stop,
+        method: InterpolationMethod,
+    }{
+        .{
+            .name = "basic",
+            .expected = .{
+                .start = .{ .x = 0, .y = 0 },
+                .end = .{ .x = 99, .y = 99 },
+                .stops = .{
+                    .l = std.ArrayListUnmanaged(Stop).initBuffer(&buf),
+                    .interpolation_method = .linear_rgb,
+                },
+            },
+            .x0 = 0,
+            .y0 = 0,
+            .x1 = 99,
+            .y1 = 99,
+            .buffer = &buf,
+            .method = .linear_rgb,
+        },
+    };
+    const TestFn = struct {
+        fn f(tc: anytype) TestingError!void {
+            try testing.expectEqualDeep(tc.expected, Linear.initBuffer(
+                tc.x0,
+                tc.y0,
+                tc.x1,
+                tc.y1,
+                tc.buffer,
+                tc.method,
+            ));
+        }
+    };
+    try runCases(name, cases, TestFn.f);
+}
+
 test "Linear.getOffset" {
     const name = "Linear.getOffset";
     const cases = [_]struct {

--- a/src/internal/util.zig
+++ b/src/internal/util.zig
@@ -23,6 +23,7 @@ pub const TestingError = error{
     TestExpectedEqual,
     TestExpectedApproxEqAbs,
     InvalidMatrix, // Transformation.Error.InvalidMatrix
+    OutOfMemory, // std.mem.Allocator.Error
 };
 
 /// Internal vectorization function. Turns each field into a

--- a/src/painter.zig
+++ b/src/painter.zig
@@ -272,18 +272,8 @@ fn paintDirect(
                 .operator = .over,
                 .src = switch (pattern.*) {
                     .opaque_pattern => .{ .pixel = pattern.opaque_pattern.pixel },
-                    .linear_gradient => .{ .gradient = .{
-                        .underlying = .{ .linear = pattern.linear_gradient },
-                        .x = start_x,
-                        .y = y,
-                    } },
-                    .radial_gradient => .{ .gradient = .{
-                        .underlying = .{ .radial = pattern.radial_gradient },
-                        .x = start_x,
-                        .y = y,
-                    } },
-                    .conic_gradient => .{ .gradient = .{
-                        .underlying = .{ .conic = pattern.conic_gradient },
+                    .gradient => |g| .{ .gradient = .{
+                        .underlying = g,
                         .x = start_x,
                         .y = y,
                     } },
@@ -389,9 +379,7 @@ fn paintComposite(
             .operator = .in,
             .dst = switch (pattern.*) {
                 .opaque_pattern => .{ .pixel = pattern.opaque_pattern.pixel },
-                .linear_gradient => .{ .gradient = .{ .linear = pattern.linear_gradient } },
-                .radial_gradient => .{ .gradient = .{ .radial = pattern.radial_gradient } },
-                .conic_gradient => .{ .gradient = .{ .conic = pattern.conic_gradient } },
+                .gradient => .{ .gradient = pattern.gradient },
                 .dither => .{ .dither = pattern.dither },
             },
             .src = .{ .surface = &mask_sfc },

--- a/src/pattern.zig
+++ b/src/pattern.zig
@@ -21,23 +21,20 @@ const testing = @import("std").testing;
 const gradient = @import("gradient.zig");
 
 const Dither = @import("Dither.zig");
+const Gradient = @import("gradient.zig").Gradient;
 const Pixel = @import("pixel.zig").Pixel;
 
 /// Interface tags for pattern types.
 pub const PatternType = enum {
     opaque_pattern,
-    linear_gradient,
-    radial_gradient,
-    conic_gradient,
+    gradient,
     dither,
 };
 
 /// Represents an interface as a union of all patterns.
 pub const Pattern = union(PatternType) {
     opaque_pattern: OpaquePattern,
-    linear_gradient: *gradient.Linear,
-    radial_gradient: *gradient.Radial,
-    conic_gradient: *gradient.Conic,
+    gradient: *Gradient,
     dither: Dither,
 
     /// Gets the pixel data at the co-ordinates specified.

--- a/src/z2d.zig
+++ b/src/z2d.zig
@@ -44,6 +44,10 @@
 //! various color spaces. Most functions outside of the `color` package will
 //! take color as its verb-based `Color.InitArgs` form to save on boilerplate.
 //!
+//! * `Gradient` - The color gradient pattern type, providing the ability to
+//! provide transitions between colors in various patterns (linear, radial, and
+//! conic).
+//!
 //! * `Transformation` - An affine transformation matrix that transforms
 //! co-ordinates between user space and device space in `Context` and `Path`.
 //!
@@ -93,6 +97,7 @@ pub const StaticPath = @import("static_path.zig").StaticPath;
 pub const Pattern = pattern.Pattern;
 pub const Pixel = pixel.Pixel;
 pub const Color = color.Color;
+pub const Gradient = gradient.Gradient;
 pub const Surface = surface.Surface;
 pub const Transformation = @import("Transformation.zig");
 


### PR DESCRIPTION
This unifies all three gradient types under a single interface, which then is passed to the `Surface` union.

This makes things a bit easier under the hood for us, since we don't need to do a bunch of `inline else` statements for things that take gradients (dither patterns, compositor parameters, etc).

I've tried to make the interface intuitive, there's some wordy parts because we don't use tuples like in `Color.InitArgs`, but it also helps us document gradients at the top level.