### PR TITLE
Pre-release API cleanup

### DIFF
--- a/src/Dither.zig
+++ b/src/Dither.zig
@@ -10,9 +10,7 @@
 //! the appropriate functionality in the `compositor` package.
 const Dither = @This();
 
-const debug = @import("std").debug;
 const math = @import("std").math;
-const mem = @import("std").mem;
 const testing = @import("std").testing;
 
 const colorpkg = @import("color.zig");
@@ -23,11 +21,7 @@ const Gradient = gradientpkg.Gradient;
 const Pixel = pixelpkg.Pixel;
 
 const dither_blue_noise_64x64 = @import("internal/blue_noise.zig").dither_blue_noise_64x64;
-const vector_length = @import("compositor.zig").vector_length;
 
-const gather = @import("internal/util.zig").gather;
-const splat = @import("internal/util.zig").splat;
-const vectorize = @import("internal/util.zig").vectorize;
 const runCases = @import("internal/util.zig").runCases;
 const TestingError = @import("internal/util.zig").TestingError;
 
@@ -103,99 +97,8 @@ pub fn getPixel(self: *const Dither, x: i32, y: i32) Pixel {
     }).asPixel();
 }
 
-/// Vectorized version of `getPixel`. Designed for internal use by the
-/// compositor; YMMV when using externally.
-pub fn getRGBAVec(
-    self: *const Dither,
-    x: i32,
-    y: i32,
-    comptime limit: bool,
-    limit_len: usize,
-) vectorize(pixelpkg.RGBA) {
-    return colorpkg.LinearRGB.encodeRGBAVec(self.getColorVec(
-        x,
-        y,
-        limit,
-        limit_len,
-    ));
-}
-
-const zero_float_vec = @import("internal/util.zig").zero_float_vec;
-const zero_color_vec = @import("internal/util.zig").zero_color_vec;
-
-/// Vectorized color dithering. Designed for internal use by the compositor;
-/// YMMV when using externally.
-pub fn getColorVec(
-    self: *const Dither,
-    x: i32,
-    y: i32,
-    comptime limit: bool,
-    limit_len: usize,
-) colorpkg.LinearRGB.Vector {
-    if (limit) debug.assert(limit_len < vector_length);
-    const rgba: vectorize(colorpkg.LinearRGB) = switch (self.source) {
-        .pixel => |src| c: {
-            const c = colorpkg.LinearRGB.decodeRGBA(pixelpkg.RGBA.fromPixel(src));
-            break :c .{
-                .r = @splat(c.r),
-                .g = @splat(c.g),
-                .b = @splat(c.b),
-                .a = @splat(c.a),
-            };
-        },
-        .color => |src| c: {
-            const c = colorpkg.LinearRGB.fromColor(Color.init(src));
-            break :c .{
-                .r = @splat(c.r),
-                .g = @splat(c.g),
-                .b = @splat(c.b),
-                .a = @splat(c.a),
-            };
-        },
-        .gradient => |src| c: {
-            var c0_vec: [vector_length]colorpkg.Color = zero_color_vec;
-            var c1_vec: [vector_length]colorpkg.Color = zero_color_vec;
-            var offsets_vec: [vector_length]f32 = zero_float_vec;
-            for (0..vector_length) |i| {
-                const search_result = src.searchInStops(src.getOffset(
-                    x + @as(i32, @intCast(i)),
-                    y,
-                ));
-                c0_vec[i] = search_result.c0;
-                c1_vec[i] = search_result.c1;
-                offsets_vec[i] = search_result.offset;
-                if (limit) {
-                    if (i + 1 == limit_len) break;
-                }
-            }
-            break :c src.getInterpolationMethod().interpolateVec(
-                c0_vec,
-                c1_vec,
-                offsets_vec,
-            );
-        },
-    };
-    const m: @Vector(vector_length, f32) = switch (self.type) {
-        .none => return rgba,
-        .bayer => mBayer8x8Vec(x, y),
-        .blue_noise => mBlueNoise64x64Vec(x, y),
-    };
-    const scale = splat(f32, 1.0 / @as(
-        f32,
-        @floatFromInt((@as(usize, 1) << self.scale) - 1),
-    ));
-    return .{
-        .r = apply_dither(rgba.r, m, scale),
-        .g = apply_dither(rgba.g, m, scale),
-        .b = apply_dither(rgba.b, m, scale),
-        .a = apply_dither(rgba.a, m, scale),
-    };
-}
-
-fn apply_dither(value: anytype, m: anytype, scale: anytype) @TypeOf(value) {
-    const lower = if (@typeInfo(@TypeOf(value)) == .Vector) splat(f32, 0.0) else 0.0;
-    const upper = if (@typeInfo(@TypeOf(value)) == .Vector) splat(f32, 1.0) else 1.0;
-    return math.clamp(value + m * scale, lower, upper);
+fn apply_dither(value: f32, m: f32, scale: f32) f32 {
+    return math.clamp(value + m * scale, 0.0, 1.0);
 }
 
 // Virtual matrix functions for computing pre-calculated threshold values for
@@ -243,34 +146,6 @@ fn mBayer8x8(x: i32, y: i32) f32 {
     return @as(f32, @floatFromInt(m)) * (2.0 / 128.0) - (63.0 / 128.0);
 }
 
-// Vectorized version of the virtual pre-calculated Bayer 8x8 matrix, just
-// easier than a fully generic version.
-fn mBayer8x8Vec(x: i32, y: i32) @Vector(vector_length, f32) {
-    // Construct our x-vector
-    var _x: @Vector(vector_length, i32) = undefined;
-    for (0..vector_length) |i| _x[i] = x + @as(i32, @intCast(i));
-
-    // Set up our xor-ed y-vector
-    const _y = splat(i32, y) ^ _x;
-
-    // Some literals cuz this is gonna get meaty
-    const _x1 = splat(i32, 1);
-    const _x2 = splat(i32, 2);
-    const _x4 = splat(i32, 4);
-    const sh5 = splat(u5, 5);
-    const sh4 = splat(u5, 4);
-    const sh2 = splat(u5, 2);
-    const sh1 = splat(u5, 1);
-    const _f2 = splat(f32, 2.0);
-    const _f63 = splat(f32, 63.0);
-    const _f128 = splat(f32, 128.0);
-
-    const m: @Vector(vector_length, u32) = @intCast((_y & _x1) << sh5 | (_x & _x1) << sh4 |
-        (_y & _x2) << sh2 | (_x & _x2) << sh1 |
-        (_y & _x4) >> sh1 | (_x & _x4) >> sh2);
-    return @as(@Vector(vector_length, f32), @floatFromInt(m)) * (_f2 / _f128) - (_f63 / _f128);
-}
-
 fn mBlueNoise64x64(x: i32, y: i32) f32 {
     // The index for looking up into the blue noise matrix (any matrix for
     // ordered dithering, actually) is (mod(x), mod(y)). Our blue noise matrix
@@ -280,22 +155,6 @@ fn mBlueNoise64x64(x: i32, y: i32) f32 {
     const m = dither_blue_noise_64x64[idx];
     // As with the bayer 8x8, we apply the normalized offset w/epsilon.
     return @as(f32, @floatFromInt(m)) * (2.0 / 8192.0) - (4095.0 / 8192.0);
-}
-
-fn mBlueNoise64x64Vec(x: i32, y: i32) @Vector(vector_length, f32) {
-    var _x: @Vector(vector_length, i32) = undefined;
-    for (0..vector_length) |i| _x[i] = x + @as(i32, @intCast(i));
-    const _y = splat(i32, y);
-
-    const _i64 = splat(i32, 64);
-    const sh6 = splat(u5, 6);
-    const _f2 = splat(f32, 2.0);
-    const _f4095 = splat(f32, 4095.0);
-    const _f8192 = splat(f32, 8192.0);
-
-    const idx: @Vector(vector_length, usize) = @intCast(@mod(_x, _i64) << sh6 | @mod(_y, _i64));
-    const m = gather(@as([]const u16, @ptrCast(&dither_blue_noise_64x64)), idx);
-    return @as(@Vector(vector_length, f32), @floatFromInt(m)) * (_f2 / _f8192) - (_f4095 / _f8192);
 }
 
 // Note that most of our tests will end up only doing rudimentary tests here
@@ -401,93 +260,6 @@ test "Dither.getPixel" {
                 .scale = tc.scale,
             };
             try testing.expectEqualDeep(tc.expected, d.getPixel(tc.x, tc.y));
-        }
-    };
-    try runCases(name, cases, TestFn.f);
-}
-
-test "Dither.getRGBAVec" {
-    const name = "Dither.getRGBAVec";
-    const cases = [_]struct {
-        name: []const u8,
-        type: Type,
-        source: union(enum) {
-            pixel: Pixel,
-            color: Color.InitArgs,
-            gradient: void,
-        },
-        scale: u4,
-        x: i32,
-        y: i32,
-    }{
-        .{
-            .name = "no dither",
-            .type = .none,
-            .source = .{ .pixel = .{ .rgba = .{ .r = 255, .g = 255, .b = 255, .a = 255 } } },
-            .scale = 1, // Driving the scale down here should validate the short-circuit
-            .x = 0,
-            .y = 0,
-        },
-        .{
-            .name = "pixel",
-            .type = .bayer,
-            .source = .{ .pixel = .{ .rgba = .{ .r = 255, .g = 255, .b = 255, .a = 255 } } },
-            .scale = 8,
-            .x = 0,
-            .y = 0,
-        },
-        .{
-            .name = "color",
-            .type = .bayer,
-            .source = .{ .color = .{ .rgb = .{ 1, 1, 1 } } },
-            .scale = 8,
-            .x = 0,
-            .y = 0,
-        },
-        .{
-            .name = "gradient",
-            .type = .bayer,
-            .source = .gradient,
-            .scale = 8,
-            .x = 49,
-            .y = 20,
-        },
-        .{
-            .name = "blue noise",
-            .type = .blue_noise,
-            .source = .gradient,
-            .scale = 8,
-            .x = 0,
-            .y = 49,
-        },
-    };
-    const TestFn = struct {
-        fn f(tc: anytype) TestingError!void {
-            var stop_buffer: [2]gradientpkg.Stop = undefined;
-            var g: Gradient = Gradient.init(.{
-                .type = .{
-                    .linear = .{ .x0 = 0, .y0 = 0, .x1 = 99, .y1 = 99 },
-                },
-                .stops = &stop_buffer,
-            });
-            const d: Dither = .{
-                .type = tc.type,
-                .source = switch (tc.source) {
-                    .pixel => |s| .{ .pixel = s },
-                    .color => |s| .{ .color = s },
-                    .gradient => .{ .gradient = &g },
-                },
-                .scale = tc.scale,
-            };
-            var expected: vectorize(pixelpkg.RGBA) = undefined;
-            for (0..vector_length) |i| {
-                const expected_scalar = pixelpkg.RGBA.fromPixel(d.getPixel(tc.x + @as(i32, @intCast(i)), tc.y));
-                expected.r[i] = expected_scalar.r;
-                expected.g[i] = expected_scalar.g;
-                expected.b[i] = expected_scalar.b;
-                expected.a[i] = expected_scalar.a;
-            }
-            try testing.expectEqualDeep(expected, d.getRGBAVec(tc.x, tc.y, false, 0));
         }
     };
     try runCases(name, cases, TestFn.f);

--- a/src/color.zig
+++ b/src/color.zig
@@ -208,9 +208,6 @@ fn RGB(profile: RGBProfile) type {
     return struct {
         const Self = @This();
 
-        /// The color profile for this sRGB type.
-        pub const color_profile = profile;
-
         /// The fast-gamma correction value.
         pub const gamma: f32 = switch (profile) {
             .linear => 1.0,

--- a/src/compositor.zig
+++ b/src/compositor.zig
@@ -2241,8 +2241,8 @@ const FloatOps = struct {
 };
 
 const max_u8_scalar: u16 = 255;
-const max_u8_vec: @Vector(vector_length, u16) = @splat(255);
-const zero_int_vec: @Vector(vector_length, u16) = @splat(0);
+const max_u8_vec = splat(u16, 255);
+const zero_int_vec = splat(u16, 0);
 const zero_float_vec = @import("internal/util.zig").zero_float_vec;
 const zero_color_vec = @import("internal/util.zig").zero_color_vec;
 

--- a/src/export_png.zig
+++ b/src/export_png.zig
@@ -17,7 +17,6 @@ const pixel_vector = @import("internal/pixel_vector.zig");
 const surface = @import("surface.zig");
 
 const vector_length = @import("compositor.zig").vector_length;
-const splat = @import("internal/util.zig").splat;
 
 const native_endian = builtin.cpu.arch.endian();
 

--- a/src/export_png.zig
+++ b/src/export_png.zig
@@ -11,6 +11,7 @@ const mem = @import("std").mem;
 const zlib = @import("std").compress.zlib;
 
 const color = @import("color.zig");
+const color_vector = @import("internal/color_vector.zig");
 const pixel = @import("pixel.zig");
 const surface = @import("surface.zig");
 
@@ -37,12 +38,12 @@ pub const WriteToPNGFileError = Error ||
     fs.File.WriteError;
 
 pub const WriteToPNGFileOptions = struct {
-    // The RGB/color profile to use for exporting.
-    //
-    // When set, the gAMA header is set appropriately for the gamma transfer
-    // number, and the image data is re-encoded with the gamma if necessary.
-    //
-    // The default is to not add the gAMA header or encode the gamma.
+    /// The RGB/color profile to use for exporting.
+    ///
+    /// When set, the gAMA header is set appropriately for the gamma transfer
+    /// number, and the image data is re-encoded with the gamma if necessary.
+    ///
+    /// The default is to not add the gAMA header or encode the gamma.
     color_profile: ?color.RGBProfile = null,
 };
 
@@ -333,14 +334,14 @@ fn encodeRGBAVec(
     // see if we need to decode and apply the gamma for that. More formats may
     // come later.
     if (profile orelse .linear == .srgb) {
-        var decoded = color.SRGB.decodeRGBAVecRaw(.{
+        var decoded = color_vector.SRGB.decodeRGBAVecRaw(.{
             .r = @intCast(rgba_vector.r),
             .g = @intCast(rgba_vector.g),
             .b = @intCast(rgba_vector.b),
             .a = @intCast(rgba_vector.a),
         });
-        decoded = color.SRGB.applyGammaVec(decoded);
-        const encoded = color.SRGB.encodeRGBAVecRaw(decoded);
+        decoded = color_vector.SRGB.applyGammaVec(decoded);
+        const encoded = color_vector.SRGB.encodeRGBAVecRaw(decoded);
         rgba_vector.r = encoded.r;
         rgba_vector.g = encoded.g;
         rgba_vector.b = encoded.b;

--- a/src/gradient.zig
+++ b/src/gradient.zig
@@ -21,8 +21,6 @@ const Transformation = @import("Transformation.zig");
 const runCases = @import("internal/util.zig").runCases;
 const TestingError = @import("internal/util.zig").TestingError;
 
-const vector_length = @import("compositor.zig").vector_length;
-
 /// Interface tags for gradient types.
 pub const GradientType = enum {
     linear,

--- a/src/internal/color_vector.zig
+++ b/src/internal/color_vector.zig
@@ -1,0 +1,1319 @@
+// SPDX-License-Identifier: MPL-2.0
+//   Copyright © 2024 Chris Marchesi
+
+//! Internal vector types and helpers for color functionality.
+
+const debug = @import("std").debug;
+const math = @import("std").math;
+const testing = @import("std").testing;
+
+const color = @import("../color.zig");
+const gradient = @import("../gradient.zig");
+const pixel = @import("../pixel.zig");
+
+const Dither = @import("../Dither.zig");
+
+const gather = @import("util.zig").gather;
+const splat = @import("util.zig").splat;
+const vectorize = @import("util.zig").vectorize;
+const runCases = @import("util.zig").runCases;
+const TestingError = @import("util.zig").TestingError;
+
+const vector_length = @import("../compositor.zig").vector_length;
+const zero_float_vec = @import("util.zig").zero_float_vec;
+const zero_color_vec = @import("util.zig").zero_color_vec;
+const dither_blue_noise_64x64 = @import("blue_noise.zig").dither_blue_noise_64x64;
+
+/// Vectorized version of `interpolate`. Designed for internal use by
+/// the compositor; YMMV when using externally.
+pub fn interpolateVec(
+    method: color.InterpolationMethod,
+    a: [vector_length]color.Color,
+    b: [vector_length]color.Color,
+    t: [vector_length]f32,
+) LinearRGB.T {
+    return switch (method) {
+        .linear_rgb => LinearRGB.interpolateVec(
+            LinearRGB.fromColorVec(a),
+            LinearRGB.fromColorVec(b),
+            t,
+        ),
+        // The main reason that interpolateVec exists is for dithering, which
+        // expects linear space. So we need to add the additional step of
+        // removing the gamma. After this we can just return without additional
+        // coercion (this happens automatically).
+        .srgb => SRGB.removeGammaVec(SRGB.interpolateVec(
+            SRGB.fromColorVec(a),
+            SRGB.fromColorVec(b),
+            t,
+        )),
+        .hsl => |polar_method| HSL.toRGBVec(HSL.interpolateVec(
+            HSL.fromColorVec(a),
+            HSL.fromColorVec(b),
+            t,
+            polar_method,
+        )),
+    };
+}
+
+/// Vectorized version of `interpolateEncode`. Designed for internal use by
+/// the compositor; YMMV when using externally.
+pub fn interpolateEncodeVec(
+    method: color.InterpolationMethod,
+    a: [vector_length]color.Color,
+    b: [vector_length]color.Color,
+    t: [vector_length]f32,
+) vectorize(pixel.RGBA) {
+    return switch (method) {
+        .linear_rgb => LinearRGB.interpolateEncodeVec(
+            LinearRGB.fromColorVec(a),
+            LinearRGB.fromColorVec(b),
+            t,
+        ),
+        .srgb => SRGB.interpolateEncodeVec(
+            SRGB.fromColorVec(a),
+            SRGB.fromColorVec(b),
+            t,
+        ),
+        .hsl => |polar_method| HSL.interpolateEncodeVec(
+            HSL.fromColorVec(a),
+            HSL.fromColorVec(b),
+            t,
+            polar_method,
+        ),
+    };
+}
+
+/// Vectorized version of `getPixel`. Designed for internal use by the
+/// compositor; YMMV when using externally.
+pub fn fromDitherVecEncode(
+    dither: *const Dither,
+    x: i32,
+    y: i32,
+    comptime limit: bool,
+    limit_len: usize,
+) vectorize(pixel.RGBA) {
+    return LinearRGB.encodeRGBAVec(fromDitherVec(
+        dither,
+        x,
+        y,
+        limit,
+        limit_len,
+    ));
+}
+
+/// Vectorized color dithering. Designed for internal use by the compositor;
+/// YMMV when using externally.
+pub fn fromDitherVec(
+    dither: *const Dither,
+    x: i32,
+    y: i32,
+    comptime limit: bool,
+    limit_len: usize,
+) LinearRGB.T {
+    if (limit) debug.assert(limit_len < vector_length);
+    const rgba: LinearRGB.T = switch (dither.source) {
+        .pixel => |src| c: {
+            const c = color.LinearRGB.decodeRGBA(pixel.RGBA.fromPixel(src));
+            break :c .{
+                .r = @splat(c.r),
+                .g = @splat(c.g),
+                .b = @splat(c.b),
+                .a = @splat(c.a),
+            };
+        },
+        .color => |src| c: {
+            const c = color.LinearRGB.fromColor(color.Color.init(src));
+            break :c .{
+                .r = @splat(c.r),
+                .g = @splat(c.g),
+                .b = @splat(c.b),
+                .a = @splat(c.a),
+            };
+        },
+        .gradient => |src| c: {
+            var c0_vec: [vector_length]color.Color = zero_color_vec;
+            var c1_vec: [vector_length]color.Color = zero_color_vec;
+            var offsets_vec: [vector_length]f32 = zero_float_vec;
+            for (0..vector_length) |i| {
+                const search_result = src.searchInStops(src.getOffset(
+                    x + @as(i32, @intCast(i)),
+                    y,
+                ));
+                c0_vec[i] = search_result.c0;
+                c1_vec[i] = search_result.c1;
+                offsets_vec[i] = search_result.offset;
+                if (limit) {
+                    if (i + 1 == limit_len) break;
+                }
+            }
+            break :c interpolateVec(
+                src.getInterpolationMethod(),
+                c0_vec,
+                c1_vec,
+                offsets_vec,
+            );
+        },
+    };
+    const m: @Vector(vector_length, f32) = switch (dither.type) {
+        .none => return rgba,
+        .bayer => mBayer8x8Vec(x, y),
+        .blue_noise => mBlueNoise64x64Vec(x, y),
+    };
+    const scale = splat(f32, 1.0 / @as(
+        f32,
+        @floatFromInt((@as(usize, 1) << dither.scale) - 1),
+    ));
+    return .{
+        .r = apply_dither(rgba.r, m, scale),
+        .g = apply_dither(rgba.g, m, scale),
+        .b = apply_dither(rgba.b, m, scale),
+        .a = apply_dither(rgba.a, m, scale),
+    };
+}
+
+fn apply_dither(
+    value: @Vector(vector_length, f32),
+    m: @Vector(vector_length, f32),
+    scale: @Vector(vector_length, f32),
+) @Vector(vector_length, f32) {
+    const lower = splat(f32, 0.0);
+    const upper = splat(f32, 1.0);
+    return math.clamp(value + m * scale, lower, upper);
+}
+
+pub const LinearRGB = RGBVec(color.LinearRGB);
+pub const SRGB = RGBVec(color.SRGB);
+
+fn RGBVec(comptime underlying_T: type) type {
+    return struct {
+        pub const T = vectorize(underlying_T);
+
+        /// Vectorizes a vector-sized array of colors translated to RGB,
+        /// gamma-corrected.
+        fn fromColorVec(src: [vector_length]color.Color) T {
+            var result: T = undefined;
+            for (src, 0..) |c, i| {
+                const s = underlying_T.fromColor(c);
+                result.r[i] = s.r;
+                result.g[i] = s.g;
+                result.b[i] = s.b;
+                result.a[i] = s.a;
+            }
+            return result;
+        }
+
+        /// Vectorized version of applyGamma.
+        pub fn applyGammaVec(src: T) T {
+            if (underlying_T == color.LinearRGB) {
+                return src;
+            }
+            // math.pow is not implemented for vectors, so we need to do this
+            // element-by-element.
+            var result: T = undefined;
+            for (0..vector_length) |i| {
+                result.r[i] = math.pow(f32, src.r[i], 1 / underlying_T.gamma);
+                result.g[i] = math.pow(f32, src.g[i], 1 / underlying_T.gamma);
+                result.b[i] = math.pow(f32, src.b[i], 1 / underlying_T.gamma);
+                result.a[i] = src.a[i];
+            }
+            return result;
+        }
+
+        /// Vectorized version of removeGamma.
+        fn removeGammaVec(src: T) T {
+            if (underlying_T == color.LinearRGB) {
+                return src;
+            }
+            // math.pow is not implemented for vectors, so we need to do this
+            // element-by-element.
+            var result: T = undefined;
+            for (0..vector_length) |i| {
+                result.r[i] = math.pow(f32, src.r[i], underlying_T.gamma);
+                result.g[i] = math.pow(f32, src.g[i], underlying_T.gamma);
+                result.b[i] = math.pow(f32, src.b[i], underlying_T.gamma);
+                result.a[i] = src.a[i];
+            }
+            return result;
+        }
+
+        /// Vectorized version of encodeRGBA, used internally.
+        fn encodeRGBAVec(src: T) vectorize(pixel.RGBA) {
+            // NOTE: we have other implementations of a 16-bit vectorized RGBA
+            // value in the compositor package. I'm refraining from making that
+            // public for the time being as this is currently the only case
+            // where we need it outside of that package, but it's a possibility
+            // if its use grows.
+            const _src = if (underlying_T != color.LinearRGB)
+                removeGammaVec(src)
+            else
+                src;
+
+            const result: struct {
+                r: @Vector(vector_length, u16),
+                g: @Vector(vector_length, u16),
+                b: @Vector(vector_length, u16),
+                a: @Vector(vector_length, u16),
+            } = .{
+                .r = @intFromFloat(@round(splat(f32, 255.0) * _src.r)),
+                .g = @intFromFloat(@round(splat(f32, 255.0) * _src.g)),
+                .b = @intFromFloat(@round(splat(f32, 255.0) * _src.b)),
+                .a = @intFromFloat(@round(splat(f32, 255.0) * _src.a)),
+            };
+            return .{
+                .r = @intCast(result.r * result.a / splat(u16, 255)),
+                .g = @intCast(result.g * result.a / splat(u16, 255)),
+                .b = @intCast(result.b * result.a / splat(u16, 255)),
+                .a = @intCast(result.a),
+            };
+        }
+
+        /// Like decodeRGBARaw, but converts vectorized RGBA pixel values to
+        /// vectorized colors. Used internally.
+        pub fn decodeRGBAVecRaw(src: vectorize(pixel.RGBA)) T {
+            return .{
+                .r = @as(@Vector(vector_length, f32), @floatFromInt(src.r)) / splat(f32, 255.0),
+                .g = @as(@Vector(vector_length, f32), @floatFromInt(src.g)) / splat(f32, 255.0),
+                .b = @as(@Vector(vector_length, f32), @floatFromInt(src.b)) / splat(f32, 255.0),
+                .a = @as(@Vector(vector_length, f32), @floatFromInt(src.a)) / splat(f32, 255.0),
+            };
+        }
+
+        /// Like encodeRGBARaw, but converts vectorized colors to vectorized RGBA
+        /// values. Used internally.
+        pub fn encodeRGBAVecRaw(src: T) vectorize(pixel.RGBA) {
+            return .{
+                .r = @intFromFloat(@round(splat(f32, 255.0) * src.r)),
+                .g = @intFromFloat(@round(splat(f32, 255.0) * src.g)),
+                .b = @intFromFloat(@round(splat(f32, 255.0) * src.b)),
+                .a = @intFromFloat(@round(splat(f32, 255.0) * src.a)),
+            };
+        }
+
+        /// Internally-used vectorized version of multiply.
+        fn multiplyVec(src: T) T {
+            return .{
+                .r = src.r * src.a,
+                .g = src.g * src.a,
+                .b = src.b * src.a,
+                .a = src.a,
+            };
+        }
+
+        /// Internally-used vectorized version of demultiply.
+        fn demultiplyVec(src: T) T {
+            return .{
+                .r = @select(f32, src.a == splat(f32, 0), splat(f32, 0), src.r / src.a),
+                .g = @select(f32, src.a == splat(f32, 0), splat(f32, 0), src.g / src.a),
+                .b = @select(f32, src.a == splat(f32, 0), splat(f32, 0), src.b / src.a),
+                .a = src.a,
+            };
+        }
+
+        /// Internal interpolation function for vectors.
+        fn interpolateVec(
+            a: T,
+            b: T,
+            t: @Vector(vector_length, f32),
+        ) T {
+            const a_mul = multiplyVec(a);
+            const b_mul = multiplyVec(b);
+            const interpolated: T = .{
+                .r = lerp(a_mul.r, b_mul.r, t),
+                .g = lerp(a_mul.g, b_mul.g, t),
+                .b = lerp(a_mul.b, b_mul.b, t),
+                .a = lerp(a_mul.a, b_mul.a, t),
+            };
+            return demultiplyVec(interpolated);
+        }
+
+        /// Like interpolateEncode, but runs on vectors.
+        fn interpolateEncodeVec(
+            a: T,
+            b: T,
+            t: @Vector(vector_length, f32),
+        ) vectorize(pixel.RGBA) {
+            const a_mul = multiplyVec(a);
+            const b_mul = multiplyVec(b);
+            const interpolated: T = .{
+                .r = lerp(a_mul.r, b_mul.r, t),
+                .g = lerp(a_mul.g, b_mul.g, t),
+                .b = lerp(a_mul.b, b_mul.b, t),
+                .a = lerp(a_mul.a, b_mul.a, t),
+            };
+            if (underlying_T == color.LinearRGB) {
+                return encodeRGBAVecRaw(interpolated);
+            }
+
+            return encodeRGBAVec(demultiplyVec(interpolated));
+        }
+    };
+}
+
+pub const HSL = struct {
+    pub const T = vectorize(color.HSL);
+
+    /// Vectorizes a slice of colors translated to HSL.
+    fn fromColorVec(src: [vector_length]color.Color) T {
+        var result: T = undefined;
+        for (src, 0..) |c, i| {
+            const s = color.HSL.fromColor(c);
+            result.h[i] = s.h;
+            result.s[i] = s.s;
+            result.l[i] = s.l;
+            result.a[i] = s.a;
+        }
+        return result;
+    }
+
+    fn toRGBVec(src: T) LinearRGB.T {
+        var hue = @rem(src.h, splat(f32, 360));
+        hue = @select(f32, hue < splat(f32, 0), hue + splat(f32, 360), hue);
+
+        return .{
+            .r = toRGBChannelVec(splat(f32, 0), hue, src.s, src.l),
+            .g = toRGBChannelVec(splat(f32, 8), hue, src.s, src.l),
+            .b = toRGBChannelVec(splat(f32, 4), hue, src.s, src.l),
+            .a = src.a,
+        };
+    }
+
+    fn toRGBChannelVec(
+        n: @Vector(vector_length, f32),
+        hue: @Vector(vector_length, f32),
+        sat: @Vector(vector_length, f32),
+        light: @Vector(vector_length, f32),
+    ) @Vector(vector_length, f32) {
+        const k = @rem((n + hue / splat(f32, 30)), splat(f32, 12));
+        const a = sat * @min(light, splat(f32, 1) - light);
+        return light - a * @max(splat(f32, -1), @min(k - splat(f32, 3), splat(f32, 9) - k, splat(f32, 1)));
+    }
+
+    fn multiplyVec(src: T) T {
+        return .{
+            .h = src.h,
+            .s = src.s * src.a,
+            .l = src.l * src.a,
+            .a = src.a,
+        };
+    }
+
+    fn demultiplyVec(src: T) T {
+        return .{
+            .h = src.h,
+            .s = @select(f32, src.a == splat(f32, 0), splat(f32, 0), src.s / src.a),
+            .l = @select(f32, src.a == splat(f32, 0), splat(f32, 0), src.l / src.a),
+            .a = src.a,
+        };
+    }
+
+    /// Internal interpolation function for vectors.
+    fn interpolateVec(
+        a: T,
+        b: T,
+        t: @Vector(vector_length, f32),
+        method: color.InterpolationMethod.Polar,
+    ) T {
+        const a_mul = multiplyVec(a);
+        const b_mul = multiplyVec(b);
+        var a_mul_h = a_mul.h;
+        var b_mul_h = b_mul.h;
+
+        switch (method) {
+            .shorter => {
+                const gt_cond = b_mul_h - a_mul_h > splat(f32, 180);
+                const lt_cond = b_mul_h - a_mul_h < splat(f32, -180);
+                a_mul_h = @select(f32, gt_cond, a_mul_h + splat(f32, 360), a_mul_h);
+                b_mul_h = @select(f32, lt_cond, b_mul_h + splat(f32, 360), b_mul_h);
+            },
+            .longer => {
+                const delta = b_mul_h - a_mul_h;
+                const zero_180_cond = (@intFromBool(splat(f32, 0) < delta) &
+                    @intFromBool(delta < splat(f32, 180))) != splat(u1, 0);
+                const neg_180_zero_cond = (@intFromBool(splat(f32, -180) < delta) &
+                    @intFromBool(delta <= splat(f32, 0))) != splat(u1, 0);
+                a_mul_h = @select(f32, zero_180_cond, a_mul_h + splat(f32, 360), a_mul_h);
+                b_mul_h = @select(f32, neg_180_zero_cond, b_mul_h + splat(f32, 360), b_mul_h);
+            },
+            .increasing => {
+                const lt_cond = b_mul_h < a_mul_h;
+                b_mul_h = @select(f32, lt_cond, b_mul_h + splat(f32, 360), b_mul_h);
+            },
+            .decreasing => {
+                const lt_cond = a_mul_h < b_mul_h;
+                a_mul_h = @select(f32, lt_cond, a_mul_h + splat(f32, 360), a_mul_h);
+            },
+        }
+
+        const h_result = lerpPolar(a_mul.h, a_mul_h, b_mul_h, t);
+        return demultiplyVec(T{
+            .h = @mod(h_result, splat(f32, 360)),
+            .s = lerp(a_mul.s, b_mul.s, t),
+            .l = lerp(a_mul.l, b_mul.l, t),
+            .a = lerp(a_mul.a, b_mul.a, t),
+        });
+    }
+
+    /// Like interpolateEncode, but runs on vectors.
+    fn interpolateEncodeVec(
+        a: T,
+        b: T,
+        t: @Vector(vector_length, f32),
+        method: color.InterpolationMethod.Polar,
+    ) vectorize(pixel.RGBA) {
+        return LinearRGB.encodeRGBAVec(toRGBVec(HSL.interpolateVec(a, b, t, method)));
+    }
+};
+
+/// Internal linear interpolation function used for color processing.
+fn lerp(
+    a: @Vector(vector_length, f32),
+    b: @Vector(vector_length, f32),
+    t: @Vector(vector_length, f32),
+) @Vector(vector_length, f32) {
+    return a + (b - a) * t;
+}
+
+/// Internal linear interpolation function used for polar values.
+fn lerpPolar(
+    a: @Vector(vector_length, f32),
+    b: @Vector(vector_length, f32),
+    c: @Vector(vector_length, f32),
+    t: @Vector(vector_length, f32),
+) @Vector(vector_length, f32) {
+    return a + (c - b) * t;
+}
+
+// Vectorized version of the virtual pre-calculated Bayer 8x8 matrix, just
+// easier than a fully generic version.
+fn mBayer8x8Vec(x: i32, y: i32) @Vector(vector_length, f32) {
+    // Construct our x-vector
+    var _x: @Vector(vector_length, i32) = undefined;
+    for (0..vector_length) |i| _x[i] = x + @as(i32, @intCast(i));
+
+    // Set up our xor-ed y-vector
+    const _y = splat(i32, y) ^ _x;
+
+    // Some literals cuz this is gonna get meaty
+    const _x1 = splat(i32, 1);
+    const _x2 = splat(i32, 2);
+    const _x4 = splat(i32, 4);
+    const sh5 = splat(u5, 5);
+    const sh4 = splat(u5, 4);
+    const sh2 = splat(u5, 2);
+    const sh1 = splat(u5, 1);
+    const _f2 = splat(f32, 2.0);
+    const _f63 = splat(f32, 63.0);
+    const _f128 = splat(f32, 128.0);
+
+    const m: @Vector(vector_length, u32) = @intCast((_y & _x1) << sh5 | (_x & _x1) << sh4 |
+        (_y & _x2) << sh2 | (_x & _x2) << sh1 |
+        (_y & _x4) >> sh1 | (_x & _x4) >> sh2);
+    return @as(@Vector(vector_length, f32), @floatFromInt(m)) * (_f2 / _f128) - (_f63 / _f128);
+}
+
+fn mBlueNoise64x64Vec(x: i32, y: i32) @Vector(vector_length, f32) {
+    var _x: @Vector(vector_length, i32) = undefined;
+    for (0..vector_length) |i| _x[i] = x + @as(i32, @intCast(i));
+    const _y = splat(i32, y);
+
+    const _i64 = splat(i32, 64);
+    const sh6 = splat(u5, 6);
+    const _f2 = splat(f32, 2.0);
+    const _f4095 = splat(f32, 4095.0);
+    const _f8192 = splat(f32, 8192.0);
+
+    const idx: @Vector(vector_length, usize) = @intCast(@mod(_x, _i64) << sh6 | @mod(_y, _i64));
+    const m = gather(@as([]const u16, @ptrCast(&dither_blue_noise_64x64)), idx);
+    return @as(@Vector(vector_length, f32), @floatFromInt(m)) * (_f2 / _f8192) - (_f4095 / _f8192);
+}
+
+test "LinearRGB.fromColorVec" {
+    // Simple test here designed to scale with vector_length, basically we do
+    // Red in HSL, scaling on lightness from 0 - 0.5 in 1 / vector_length
+    // intervals.
+    var colors: [vector_length]color.Color = undefined;
+    var expected: LinearRGB.T = undefined;
+    for (0..vector_length) |i| {
+        const j: f32 = @floatFromInt(i);
+        const k: f32 = @floatFromInt(vector_length);
+        colors[i] = color.HSL.init(0, 1, 0.5 * (1 / k * j), 1).asColor();
+        expected.r[i] = 1 * (1 / k * j);
+        expected.g[i] = 0;
+        expected.b[i] = 0;
+        expected.a[i] = 1;
+    }
+    const got = LinearRGB.fromColorVec(colors);
+    try testing.expectEqualDeep(expected, got);
+}
+
+test "LinearRGB.decodeRGBAVecRaw" {
+    // TODO: using pixel.RGBA's clamping for now (applies pre-multiplication
+    // for us). I don't necessarily have plans to remove the direct
+    // functionality in pixel just yet, and it helps assert behavior across
+    // color and pixel helpers, but if/when we do (likely will happen
+    // eventually) we should move this to a static test to assert, unless our
+    // testing in multiply particularly asserts that round-tripping works just
+    // fine.
+    const px_rgba = pixel.RGBA.fromClamped(0.25, 0.5, 0.75, 0.9);
+    var px_rgba_vec: vectorize(pixel.RGBA) = undefined;
+    for (0..vector_length) |i| {
+        px_rgba_vec.r[i] = px_rgba.r;
+        px_rgba_vec.g[i] = px_rgba.g;
+        px_rgba_vec.b[i] = px_rgba.b;
+        px_rgba_vec.a[i] = px_rgba.a;
+    }
+    const got_raw = color.LinearRGB.decodeRGBARaw(px_rgba);
+    const got_raw_vec = LinearRGB.decodeRGBAVecRaw(px_rgba_vec);
+
+    var expected_raw_vec: LinearRGB.T = undefined;
+    for (0..vector_length) |i| {
+        expected_raw_vec.r[i] = got_raw.r;
+        expected_raw_vec.g[i] = got_raw.g;
+        expected_raw_vec.b[i] = got_raw.b;
+        expected_raw_vec.a[i] = got_raw.a;
+    }
+
+    try testing.expectEqualDeep(expected_raw_vec, got_raw_vec);
+}
+
+test "LinearRGB.encodeRGBAVec, LinearRGB.encodeRGBAVecRaw" {
+    const in = color.LinearRGB.init(0.25, 0.5, 0.75, 0.9);
+    var in_vec: LinearRGB.T = undefined;
+    for (0..vector_length) |i| {
+        in_vec.r[i] = in.r;
+        in_vec.g[i] = in.g;
+        in_vec.b[i] = in.b;
+        in_vec.a[i] = in.a;
+    }
+    const got = color.LinearRGB.encodeRGBA(in);
+    const got_vec = LinearRGB.encodeRGBAVec(in_vec);
+    const got_raw = color.LinearRGB.encodeRGBARaw(in);
+    const got_raw_vec = LinearRGB.encodeRGBAVecRaw(in_vec);
+    var expected_vec: vectorize(pixel.RGBA) = undefined;
+    for (0..vector_length) |i| {
+        expected_vec.r[i] = got.r;
+        expected_vec.g[i] = got.g;
+        expected_vec.b[i] = got.b;
+        expected_vec.a[i] = got.a;
+    }
+    var expected_raw_vec: vectorize(pixel.RGBA) = undefined;
+    for (0..vector_length) |i| {
+        expected_raw_vec.r[i] = got_raw.r;
+        expected_raw_vec.g[i] = got_raw.g;
+        expected_raw_vec.b[i] = got_raw.b;
+        expected_raw_vec.a[i] = got_raw.a;
+    }
+    try testing.expectEqualDeep(expected_vec, got_vec);
+    try testing.expectEqualDeep(expected_raw_vec, got_raw_vec);
+}
+
+test "LinearRGB.demultiplyVec, divide by zero" {
+    // Note that we use this as a divide-by-zero check for all other generated
+    // RGB profiles.
+    const in: LinearRGB.T = .{
+        .r = @splat(1),
+        .g = @splat(0.75),
+        .b = @splat(0.25),
+        .a = @splat(0.0),
+    };
+    const got = LinearRGB.demultiplyVec(in);
+    const expected: LinearRGB.T = .{
+        .r = @splat(0.0),
+        .g = @splat(0.0),
+        .b = @splat(0.0),
+        .a = @splat(0.0),
+    };
+    try testing.expectEqualDeep(expected, got);
+}
+
+test "LinearRGB.removeGammaVec" {
+    const in = color.LinearRGB.init(0.25, 0.5, 0.75, 0.9);
+    var in_vec: LinearRGB.T = undefined;
+    for (0..vector_length) |i| {
+        in_vec.r[i] = in.r;
+        in_vec.g[i] = in.g;
+        in_vec.b[i] = in.b;
+        in_vec.a[i] = in.a;
+    }
+    const got = in.removeGamma();
+    const got_vec = LinearRGB.removeGammaVec(in_vec);
+    var expected_vec: LinearRGB.T = undefined;
+    for (0..vector_length) |i| {
+        expected_vec.r[i] = got.r;
+        expected_vec.g[i] = got.g;
+        expected_vec.b[i] = got.b;
+        expected_vec.a[i] = got.a;
+    }
+    try testing.expectEqualDeep(expected_vec, got_vec);
+}
+
+test "LinearRGB.applyGammaVec" {
+    const in = color.LinearRGB.init(0.25, 0.5, 0.75, 0.9);
+    var in_vec: LinearRGB.T = undefined;
+    for (0..vector_length) |i| {
+        in_vec.r[i] = in.r;
+        in_vec.g[i] = in.g;
+        in_vec.b[i] = in.b;
+        in_vec.a[i] = in.a;
+    }
+
+    const got = in.applyGamma();
+    const got_vec = LinearRGB.applyGammaVec(in_vec);
+    var expected_vec: LinearRGB.T = undefined;
+    for (0..vector_length) |i| {
+        expected_vec.r[i] = got.r;
+        expected_vec.g[i] = got.g;
+        expected_vec.b[i] = got.b;
+        expected_vec.a[i] = got.a;
+    }
+    try testing.expectEqualDeep(expected_vec, got_vec);
+}
+
+test "LinearRGB.interpolateVec, LinearRGB.interpolateEncodeVec" {
+    // Interpolation from red to green over the vector length.
+    const red = color.LinearRGB.init(1, 0, 0, 0.9);
+    const green = color.LinearRGB.init(0, 1, 0, 0.9);
+
+    // Build params
+    var red_vec: LinearRGB.T = undefined;
+    var green_vec: LinearRGB.T = undefined;
+    var t_vec: @Vector(vector_length, f32) = undefined;
+    for (0..vector_length) |i| {
+        red_vec.r[i] = red.r;
+        red_vec.g[i] = red.g;
+        red_vec.b[i] = red.b;
+        red_vec.a[i] = red.a;
+        green_vec.r[i] = green.r;
+        green_vec.g[i] = green.g;
+        green_vec.b[i] = green.b;
+        green_vec.a[i] = green.a;
+        const j: f32 = @floatFromInt(i);
+        const k: f32 = @floatFromInt(vector_length);
+        t_vec[i] = 1 / k * j;
+    }
+
+    // Build other params and expected RGBA set from interpolating individually
+    var expected: LinearRGB.T = undefined;
+    var expected_encoded: vectorize(pixel.RGBA) = undefined;
+    for (0..vector_length) |i| {
+        const expected_scalar = color.LinearRGB.interpolate(red, green, t_vec[i]);
+        const expected_encoded_scalar = color.LinearRGB.interpolateEncode(red, green, t_vec[i]);
+        expected.r[i] = expected_scalar.r;
+        expected.g[i] = expected_scalar.g;
+        expected.b[i] = expected_scalar.b;
+        expected.a[i] = expected_scalar.a;
+        expected_encoded.r[i] = expected_encoded_scalar.r;
+        expected_encoded.g[i] = expected_encoded_scalar.g;
+        expected_encoded.b[i] = expected_encoded_scalar.b;
+        expected_encoded.a[i] = expected_encoded_scalar.a;
+    }
+
+    const got = LinearRGB.interpolateVec(red_vec, green_vec, t_vec);
+    const got_encoded = LinearRGB.interpolateEncodeVec(red_vec, green_vec, t_vec);
+    try testing.expectEqualDeep(expected, got);
+    try testing.expectEqualDeep(expected_encoded, got_encoded);
+}
+
+test "SRGB.fromColorVec" {
+    // Simple test here designed to scale with vector_length, basically we do
+    // Red in HSL, scaling on lightness from 0 - 0.5 in 1 / vector_length
+    // intervals.
+    var colors: [vector_length]color.Color = undefined;
+    var expected: SRGB.T = undefined;
+    for (0..vector_length) |i| {
+        const j: f32 = @floatFromInt(i);
+        const k: f32 = @floatFromInt(vector_length);
+        colors[i] = color.HSL.init(0, 1, 0.5 * (1 / k * j), 1).asColor();
+        expected.r[i] = math.pow(f32, 1.0 * (1.0 / k * j), 1.0 / 2.2);
+        expected.g[i] = 0;
+        expected.b[i] = 0;
+        expected.a[i] = 1;
+    }
+    const got = SRGB.fromColorVec(colors);
+    for (0..vector_length) |i| {
+        try testing.expectApproxEqAbs(expected.r[i], got.r[i], math.floatEps(f32));
+        try testing.expectApproxEqAbs(expected.g[i], got.g[i], math.floatEps(f32));
+        try testing.expectApproxEqAbs(expected.b[i], got.b[i], math.floatEps(f32));
+        try testing.expectApproxEqAbs(expected.a[i], got.a[i], math.floatEps(f32));
+    }
+}
+
+test "SRGB.encodeRGBAVec, SRGB.encodeRGBAVecRaw" {
+    const in = color.SRGB.init(0.5296636, 0.7284379, 0.87481296, 0.9019608);
+    var in_vec: SRGB.T = undefined;
+    for (0..vector_length) |i| {
+        in_vec.r[i] = in.r;
+        in_vec.g[i] = in.g;
+        in_vec.b[i] = in.b;
+        in_vec.a[i] = in.a;
+    }
+    const got = color.SRGB.encodeRGBA(in);
+    const got_vec = SRGB.encodeRGBAVec(in_vec);
+    const got_raw = color.SRGB.encodeRGBARaw(in);
+    const got_raw_vec = SRGB.encodeRGBAVecRaw(in_vec);
+    var expected_vec: vectorize(pixel.RGBA) = undefined;
+    for (0..vector_length) |i| {
+        expected_vec.r[i] = got.r;
+        expected_vec.g[i] = got.g;
+        expected_vec.b[i] = got.b;
+        expected_vec.a[i] = got.a;
+    }
+    var expected_raw_vec: vectorize(pixel.RGBA) = undefined;
+    for (0..vector_length) |i| {
+        expected_raw_vec.r[i] = got_raw.r;
+        expected_raw_vec.g[i] = got_raw.g;
+        expected_raw_vec.b[i] = got_raw.b;
+        expected_raw_vec.a[i] = got_raw.a;
+    }
+    try testing.expectEqualDeep(expected_vec, got_vec);
+    try testing.expectEqualDeep(expected_raw_vec, got_raw_vec);
+}
+
+test "SRGB.removeGammaVec" {
+    const in = color.SRGB.init(0.25, 0.5, 0.75, 0.9);
+    var in_vec: SRGB.T = undefined;
+    for (0..vector_length) |i| {
+        in_vec.r[i] = in.r;
+        in_vec.g[i] = in.g;
+        in_vec.b[i] = in.b;
+        in_vec.a[i] = in.a;
+    }
+    const got = in.removeGamma();
+    const got_vec = SRGB.removeGammaVec(in_vec);
+    var expected_vec: SRGB.T = undefined;
+    for (0..vector_length) |i| {
+        expected_vec.r[i] = got.r;
+        expected_vec.g[i] = got.g;
+        expected_vec.b[i] = got.b;
+        expected_vec.a[i] = got.a;
+    }
+    try testing.expectEqualDeep(expected_vec, got_vec);
+}
+
+test "SRGB.applyGammaVec" {
+    const in = color.SRGB.init(0.25, 0.5, 0.75, 0.9);
+    var in_vec: SRGB.T = undefined;
+    for (0..vector_length) |i| {
+        in_vec.r[i] = in.r;
+        in_vec.g[i] = in.g;
+        in_vec.b[i] = in.b;
+        in_vec.a[i] = in.a;
+    }
+    const got = in.applyGamma();
+    const got_vec = SRGB.applyGammaVec(in_vec);
+    var expected_vec: SRGB.T = undefined;
+    for (0..vector_length) |i| {
+        expected_vec.r[i] = got.r;
+        expected_vec.g[i] = got.g;
+        expected_vec.b[i] = got.b;
+        expected_vec.a[i] = got.a;
+    }
+    try testing.expectEqualDeep(expected_vec, got_vec);
+}
+
+test "SRGB.interpolateEncodeVec" {
+    // Interpolation from red to green over the vector length.
+    const red = color.SRGB.init(1, 0, 0, 0.9);
+    const green = color.SRGB.init(0, 1, 0, 0.9);
+
+    // Build params
+    var red_vec: SRGB.T = undefined;
+    var green_vec: SRGB.T = undefined;
+    var t_vec: @Vector(vector_length, f32) = undefined;
+    for (0..vector_length) |i| {
+        red_vec.r[i] = red.r;
+        red_vec.g[i] = red.g;
+        red_vec.b[i] = red.b;
+        red_vec.a[i] = red.a;
+        green_vec.r[i] = green.r;
+        green_vec.g[i] = green.g;
+        green_vec.b[i] = green.b;
+        green_vec.a[i] = green.a;
+        const j: f32 = @floatFromInt(i);
+        const k: f32 = @floatFromInt(vector_length);
+        t_vec[i] = 1 / k * j;
+    }
+
+    // Build other params and expected RGBA set from interpolating individually
+    var expected: SRGB.T = undefined;
+    var expected_encoded: vectorize(pixel.RGBA) = undefined;
+    for (0..vector_length) |i| {
+        const expected_scalar = color.SRGB.interpolate(red, green, t_vec[i]);
+        const expected_encoded_scalar = color.SRGB.interpolateEncode(red, green, t_vec[i]);
+        expected.r[i] = expected_scalar.r;
+        expected.g[i] = expected_scalar.g;
+        expected.b[i] = expected_scalar.b;
+        expected.a[i] = expected_scalar.a;
+        expected_encoded.r[i] = expected_encoded_scalar.r;
+        expected_encoded.g[i] = expected_encoded_scalar.g;
+        expected_encoded.b[i] = expected_encoded_scalar.b;
+        expected_encoded.a[i] = expected_encoded_scalar.a;
+    }
+
+    const got = SRGB.interpolateVec(red_vec, green_vec, t_vec);
+    const got_encoded = SRGB.interpolateEncodeVec(red_vec, green_vec, t_vec);
+    try testing.expectEqualDeep(expected, got);
+    try testing.expectEqualDeep(expected_encoded, got_encoded);
+}
+
+test "HSL.fromColorVec" {
+    // This the reverse of our fromColorVec tests for RGB, with a minor
+    // modification (see below).
+    var colors: [vector_length]color.Color = undefined;
+    var expected: HSL.T = undefined;
+    for (0..vector_length) |i| {
+        // Bump j up so that it's 1-indexed versus 0-indexed, this ensures that
+        // we don't actually init black (as we'll just get a zero-value HSL
+        // back in that case).
+        const j: f32 = @floatFromInt(i + 1);
+        const k: f32 = @floatFromInt(vector_length);
+        colors[i] = color.LinearRGB.init(1 * (1 / k * j), 0, 0, 1).asColor();
+        expected.h[i] = 0;
+        expected.s[i] = 1;
+        expected.l[i] = 0.5 * (1 / k * j);
+        expected.a[i] = 1;
+    }
+    const got = HSL.fromColorVec(colors);
+    try testing.expectEqualDeep(expected, got);
+}
+
+test "HSL.toSRGBVec" {
+    // This is just the SRGBLinear.fromColorVec test for HSL -> SRGB, just with
+    // the color unwrapped.
+    var src_vec: HSL.T = undefined;
+    var expected: LinearRGB.T = undefined;
+    for (0..vector_length) |i| {
+        const j: f32 = @floatFromInt(i);
+        const k: f32 = @floatFromInt(vector_length);
+        const src = color.HSL.init(0, 1, 0.5 * (1 / k * j), 1);
+        src_vec.h[i] = src.h;
+        src_vec.s[i] = src.s;
+        src_vec.l[i] = src.l;
+        src_vec.a[i] = src.a;
+        expected.r[i] = 1 * (1 / k * j);
+        expected.g[i] = 0;
+        expected.b[i] = 0;
+        expected.a[i] = 1;
+    }
+    const got = HSL.toRGBVec(src_vec);
+    try testing.expectEqualDeep(expected, got);
+}
+
+test "HSL.demultiplyVec, divide by zero" {
+    const in: HSL.T = .{
+        .h = @splat(240),
+        .s = @splat(0.5),
+        .l = @splat(0.25),
+        .a = @splat(0.0),
+    };
+    const got = HSL.demultiplyVec(in);
+    const expected: HSL.T = .{
+        .h = @splat(240),
+        .s = @splat(0.0),
+        .l = @splat(0.0),
+        .a = @splat(0.0),
+    };
+    try testing.expectEqualDeep(expected, got);
+}
+
+test "HSL.interpolateEncodeVec" {
+    // Interpolation from red to blue over the vector length.
+    const red = color.HSL.init(0, 1, 0.5, 0.9);
+    const blue = color.HSL.init(240, 1, 0.5, 0.9);
+
+    // Build params
+    var red_vec: HSL.T = undefined;
+    var blue_vec: HSL.T = undefined;
+    var t_vec: @Vector(vector_length, f32) = undefined;
+    for (0..vector_length) |i| {
+        red_vec.h[i] = red.h;
+        red_vec.s[i] = red.s;
+        red_vec.l[i] = red.l;
+        red_vec.a[i] = red.a;
+        blue_vec.h[i] = blue.h;
+        blue_vec.s[i] = blue.s;
+        blue_vec.l[i] = blue.l;
+        blue_vec.a[i] = blue.a;
+        const j: f32 = @floatFromInt(i);
+        const k: f32 = @floatFromInt(vector_length);
+        t_vec[i] = 1 / k * j;
+    }
+
+    // Build other params and expected RGBA set from interpolating individually
+    var expected_short: vectorize(pixel.RGBA) = undefined;
+    var expected_long: vectorize(pixel.RGBA) = undefined;
+    var expected_cw: vectorize(pixel.RGBA) = undefined;
+    var expected_ccw: vectorize(pixel.RGBA) = undefined;
+    for (0..vector_length) |i| {
+        const expected_scalar_short = color.HSL.interpolateEncode(red, blue, t_vec[i], .shorter);
+        const expected_scalar_long = color.HSL.interpolateEncode(red, blue, t_vec[i], .longer);
+        const expected_scalar_cw = color.HSL.interpolateEncode(red, blue, t_vec[i], .increasing);
+        const expected_scalar_ccw = color.HSL.interpolateEncode(red, blue, t_vec[i], .decreasing);
+        expected_short.r[i] = expected_scalar_short.r;
+        expected_short.g[i] = expected_scalar_short.g;
+        expected_short.b[i] = expected_scalar_short.b;
+        expected_short.a[i] = expected_scalar_short.a;
+        expected_long.r[i] = expected_scalar_long.r;
+        expected_long.g[i] = expected_scalar_long.g;
+        expected_long.b[i] = expected_scalar_long.b;
+        expected_long.a[i] = expected_scalar_long.a;
+        expected_cw.r[i] = expected_scalar_cw.r;
+        expected_cw.g[i] = expected_scalar_cw.g;
+        expected_cw.b[i] = expected_scalar_cw.b;
+        expected_cw.a[i] = expected_scalar_cw.a;
+        expected_ccw.r[i] = expected_scalar_ccw.r;
+        expected_ccw.g[i] = expected_scalar_ccw.g;
+        expected_ccw.b[i] = expected_scalar_ccw.b;
+        expected_ccw.a[i] = expected_scalar_ccw.a;
+    }
+
+    const got_short = HSL.interpolateEncodeVec(red_vec, blue_vec, t_vec, .shorter);
+    const got_long = HSL.interpolateEncodeVec(red_vec, blue_vec, t_vec, .longer);
+    const got_cw = HSL.interpolateEncodeVec(red_vec, blue_vec, t_vec, .increasing);
+    const got_ccw = HSL.interpolateEncodeVec(red_vec, blue_vec, t_vec, .decreasing);
+    try testing.expectEqualDeep(expected_short, got_short);
+    try testing.expectEqualDeep(expected_long, got_long);
+    try testing.expectEqualDeep(expected_cw, got_cw);
+    try testing.expectEqualDeep(expected_ccw, got_ccw);
+}
+
+test "InterpolationMethod.interpolateVec, InterpolationMethod.interpolateEncodeVec" {
+    const name = "InterpolationMethod.interpolateVec, InterpolationMethod.interpolateEncodeVec";
+    const cases = [_]struct {
+        name: []const u8,
+        method: color.InterpolationMethod,
+        a: color.Color,
+        b: color.Color,
+        t: f32,
+    }{
+        .{
+            .name = ".linear_rgb, linear + linear",
+            .method = .{ .linear_rgb = {} },
+            .a = color.LinearRGB.init(1, 0, 0, 1).asColor(),
+            .b = color.LinearRGB.init(0, 1, 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".linear_rgb, HSL + linear",
+            .method = .{ .linear_rgb = {} },
+            .a = color.HSL.init(0, 1, 0.5, 1).asColor(),
+            .b = color.LinearRGB.init(0, 1, 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".linear_rgb, linear + HSL",
+            .method = .{ .linear_rgb = {} },
+            .a = color.LinearRGB.init(1, 0, 0, 1).asColor(),
+            .b = color.HSL.init(120, 1, 0.5, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".linear_rgb, HSL + HSL",
+            .method = .{ .linear_rgb = {} },
+            .a = color.HSL.init(0, 1, 0.5, 1).asColor(),
+            .b = color.HSL.init(120, 1, 0.5, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".linear_rgb, gamma + gamma",
+            .method = .{ .linear_rgb = {} },
+            .a = color.SRGB.init(math.pow(f32, 0.5, 1.0 / 2.2), 0, 0, 1).asColor(),
+            .b = color.SRGB.init(0, math.pow(f32, 0.5, 1.0 / 2.2), 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".srgb, linear + linear",
+            .method = .{ .srgb = {} },
+            .a = color.LinearRGB.init(1, 0, 0, 1).asColor(),
+            .b = color.LinearRGB.init(0, 1, 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".srgb, HSL + linear",
+            .method = .{ .srgb = {} },
+            .a = color.HSL.init(0, 1, 0.5, 1).asColor(),
+            .b = color.LinearRGB.init(0, 1, 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".srgb, linear + HSL",
+            .method = .{ .srgb = {} },
+            .a = color.LinearRGB.init(1, 0, 0, 1).asColor(),
+            .b = color.HSL.init(120, 1, 0.5, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".srgb, HSL + HSL",
+            .method = .{ .srgb = {} },
+            .a = color.HSL.init(0, 1, 0.5, 1).asColor(),
+            .b = color.HSL.init(120, 1, 0.5, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".srgb, gamma + gamma",
+            .method = .{ .srgb = {} },
+            .a = color.SRGB.init(math.pow(f32, 0.5, 1.0 / 2.2), 0, 0, 1).asColor(),
+            .b = color.SRGB.init(0, math.pow(f32, 0.5, 1.0 / 2.2), 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, shorter, linear + linear",
+            .method = .{ .hsl = .shorter },
+            .a = color.LinearRGB.init(1, 0, 0, 1).asColor(),
+            .b = color.LinearRGB.init(0, 1, 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, shorter, HSL + linear",
+            .method = .{ .hsl = .shorter },
+            .a = color.HSL.init(0, 1, 0.5, 1).asColor(),
+            .b = color.LinearRGB.init(0, 1, 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, shorter, linear + HSL",
+            .method = .{ .hsl = .shorter },
+            .a = color.LinearRGB.init(1, 0, 0, 1).asColor(),
+            .b = color.HSL.init(120, 1, 0.5, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, shorter, HSL + HSL",
+            .method = .{ .hsl = .shorter },
+            .a = color.HSL.init(0, 1, 0.5, 1).asColor(),
+            .b = color.HSL.init(120, 1, 0.5, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, shorter, gamma + gamma",
+            .method = .{ .hsl = .shorter },
+            .a = color.SRGB.init(math.pow(f32, 0.5, 1.0 / 2.2), 0, 0, 1).asColor(),
+            .b = color.SRGB.init(0, math.pow(f32, 0.5, 1.0 / 2.2), 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, longer, linear + linear",
+            .method = .{ .hsl = .longer },
+            .a = color.LinearRGB.init(1, 0, 0, 1).asColor(),
+            .b = color.LinearRGB.init(0, 1, 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, longer, HSL + linear",
+            .method = .{ .hsl = .longer },
+            .a = color.HSL.init(0, 1, 0.5, 1).asColor(),
+            .b = color.LinearRGB.init(0, 1, 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, longer, linear + HSL",
+            .method = .{ .hsl = .longer },
+            .a = color.LinearRGB.init(1, 0, 0, 1).asColor(),
+            .b = color.HSL.init(120, 1, 0.5, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, longer, HSL + HSL",
+            .method = .{ .hsl = .longer },
+            .a = color.HSL.init(0, 1, 0.5, 1).asColor(),
+            .b = color.HSL.init(120, 1, 0.5, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, longer, gamma + gamma",
+            .method = .{ .hsl = .longer },
+            .a = color.SRGB.init(math.pow(f32, 0.5, 1.0 / 2.2), 0, 0, 1).asColor(),
+            .b = color.SRGB.init(0, math.pow(f32, 0.5, 1.0 / 2.2), 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, increasing, linear + linear",
+            .method = .{ .hsl = .increasing },
+            .a = color.LinearRGB.init(1, 0, 0, 1).asColor(),
+            .b = color.LinearRGB.init(0, 1, 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, increasing, HSL + linear",
+            .method = .{ .hsl = .increasing },
+            .a = color.HSL.init(0, 1, 0.5, 1).asColor(),
+            .b = color.LinearRGB.init(0, 1, 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, increasing, linear + HSL",
+            .method = .{ .hsl = .increasing },
+            .a = color.LinearRGB.init(1, 0, 0, 1).asColor(),
+            .b = color.HSL.init(120, 1, 0.5, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, increasing, HSL + HSL",
+            .method = .{ .hsl = .increasing },
+            .a = color.HSL.init(0, 1, 0.5, 1).asColor(),
+            .b = color.HSL.init(120, 1, 0.5, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, increasing, gamma + gamma",
+            .method = .{ .hsl = .increasing },
+            .a = color.SRGB.init(math.pow(f32, 0.5, 1.0 / 2.2), 0, 0, 1).asColor(),
+            .b = color.SRGB.init(0, math.pow(f32, 0.5, 1.0 / 2.2), 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, decreasing, linear + linear",
+            .method = .{ .hsl = .decreasing },
+            .a = color.LinearRGB.init(1, 0, 0, 1).asColor(),
+            .b = color.LinearRGB.init(0, 1, 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, decreasing, HSL + linear",
+            .method = .{ .hsl = .decreasing },
+            .a = color.HSL.init(0, 1, 0.5, 1).asColor(),
+            .b = color.LinearRGB.init(0, 1, 0, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, decreasing, linear + HSL",
+            .method = .{ .hsl = .decreasing },
+            .a = color.LinearRGB.init(1, 0, 0, 1).asColor(),
+            .b = color.HSL.init(120, 1, 0.5, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, decreasing, HSL + HSL",
+            .method = .{ .hsl = .decreasing },
+            .a = color.HSL.init(0, 1, 0.5, 1).asColor(),
+            .b = color.HSL.init(120, 1, 0.5, 1).asColor(),
+            .t = 0.5,
+        },
+        .{
+            .name = ".hsl, decreasing, gamma + gamma",
+            .method = .{ .hsl = .decreasing },
+            .a = color.SRGB.init(math.pow(f32, 0.5, 1.0 / 2.2), 0, 0, 1).asColor(),
+            .b = color.SRGB.init(0, math.pow(f32, 0.5, 1.0 / 2.2), 0, 1).asColor(),
+            .t = 0.5,
+        },
+    };
+    const TestFn = struct {
+        fn f(tc: anytype) TestingError!void {
+            var a_vec: [vector_length]color.Color = undefined;
+            var b_vec: [vector_length]color.Color = undefined;
+            var t_vec: [vector_length]f32 = undefined;
+            var expected: LinearRGB.T = undefined;
+            var expected_encoded: vectorize(pixel.RGBA) = undefined;
+            for (0..vector_length) |i| {
+                a_vec[i] = tc.a;
+                b_vec[i] = tc.b;
+                const j: f32 = @floatFromInt(i);
+                const k: f32 = @floatFromInt(vector_length);
+                t_vec[i] = 1 / k * j;
+                const expected_scalar = color.LinearRGB.fromColor(tc.method.interpolate(tc.a, tc.b, t_vec[i]));
+                const expected_encoded_scalar = tc.method.interpolateEncode(tc.a, tc.b, t_vec[i]);
+                expected.r[i] = expected_scalar.r;
+                expected.g[i] = expected_scalar.g;
+                expected.b[i] = expected_scalar.b;
+                expected.a[i] = expected_scalar.a;
+                expected_encoded.r[i] = expected_encoded_scalar.r;
+                expected_encoded.g[i] = expected_encoded_scalar.g;
+                expected_encoded.b[i] = expected_encoded_scalar.b;
+                expected_encoded.a[i] = expected_encoded_scalar.a;
+            }
+            const got = interpolateVec(tc.method, a_vec, b_vec, t_vec);
+            const got_encoded = interpolateEncodeVec(tc.method, a_vec, b_vec, t_vec);
+            try testing.expectEqualDeep(expected, got);
+            try testing.expectEqualDeep(expected_encoded, got_encoded);
+        }
+    };
+    try runCases(name, cases, TestFn.f);
+}
+
+test "Dither.getRGBAVec" {
+    const name = "Dither.getRGBAVec";
+    const cases = [_]struct {
+        name: []const u8,
+        type: Dither.Type,
+        source: union(enum) {
+            pixel: pixel.Pixel,
+            color: color.Color.InitArgs,
+            gradient: void,
+        },
+        scale: u4,
+        x: i32,
+        y: i32,
+    }{
+        .{
+            .name = "no dither",
+            .type = .none,
+            .source = .{ .pixel = .{ .rgba = .{ .r = 255, .g = 255, .b = 255, .a = 255 } } },
+            .scale = 1, // Driving the scale down here should validate the short-circuit
+            .x = 0,
+            .y = 0,
+        },
+        .{
+            .name = "pixel",
+            .type = .bayer,
+            .source = .{ .pixel = .{ .rgba = .{ .r = 255, .g = 255, .b = 255, .a = 255 } } },
+            .scale = 8,
+            .x = 0,
+            .y = 0,
+        },
+        .{
+            .name = "color",
+            .type = .bayer,
+            .source = .{ .color = .{ .rgb = .{ 1, 1, 1 } } },
+            .scale = 8,
+            .x = 0,
+            .y = 0,
+        },
+        .{
+            .name = "gradient",
+            .type = .bayer,
+            .source = .gradient,
+            .scale = 8,
+            .x = 49,
+            .y = 20,
+        },
+        .{
+            .name = "blue noise",
+            .type = .blue_noise,
+            .source = .gradient,
+            .scale = 8,
+            .x = 0,
+            .y = 49,
+        },
+    };
+    const TestFn = struct {
+        fn f(tc: anytype) TestingError!void {
+            var stop_buffer: [2]gradient.Stop = undefined;
+            var g: gradient.Gradient = gradient.Gradient.init(.{
+                .type = .{
+                    .linear = .{ .x0 = 0, .y0 = 0, .x1 = 99, .y1 = 99 },
+                },
+                .stops = &stop_buffer,
+            });
+            const d: Dither = .{
+                .type = tc.type,
+                .source = switch (tc.source) {
+                    .pixel => |s| .{ .pixel = s },
+                    .color => |s| .{ .color = s },
+                    .gradient => .{ .gradient = &g },
+                },
+                .scale = tc.scale,
+            };
+            var expected: vectorize(pixel.RGBA) = undefined;
+            for (0..vector_length) |i| {
+                const expected_scalar = pixel.RGBA.fromPixel(d.getPixel(tc.x + @as(i32, @intCast(i)), tc.y));
+                expected.r[i] = expected_scalar.r;
+                expected.g[i] = expected_scalar.g;
+                expected.b[i] = expected_scalar.b;
+                expected.a[i] = expected_scalar.a;
+            }
+            try testing.expectEqualDeep(expected, fromDitherVecEncode(&d, tc.x, tc.y, false, 0));
+        }
+    };
+    try runCases(name, cases, TestFn.f);
+}

--- a/src/internal/pixel_vector.zig
+++ b/src/internal/pixel_vector.zig
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MPL-2.0
+//   Copyright © 2024 Chris Marchesi
+
+//! Internal vector types and helpers for pixel functionality.
+
+const vector_length = @import("../compositor.zig").vector_length;
+const splat = @import("util.zig").splat;
+
+/// Represents an RGBA value as a series of 16bpc vectors. Note that this is
+/// only for intermediary calculations, no channel should be bigger than an u8
+/// after any particular compositor step.
+pub const RGBA16 = struct {
+    r: @Vector(vector_length, u16),
+    g: @Vector(vector_length, u16),
+    b: @Vector(vector_length, u16),
+    a: @Vector(vector_length, u16),
+
+    pub fn premultiply(src: RGBA16) RGBA16 {
+        return .{
+            .r = src.r * src.a / splat(u16, 255),
+            .g = src.g * src.a / splat(u16, 255),
+            .b = src.b * src.a / splat(u16, 255),
+            .a = src.a,
+        };
+    }
+
+    pub fn demultiply(src: RGBA16) RGBA16 {
+        return .{
+            .r = @select(
+                u16,
+                src.a == splat(u16, 0),
+                splat(u16, 0),
+                src.r * splat(u16, 255) / @max(splat(u16, 1), src.a),
+            ),
+            .g = @select(
+                u16,
+                src.a == splat(u16, 0),
+                splat(u16, 0),
+                src.g * splat(u16, 255) / @max(splat(u16, 1), src.a),
+            ),
+            .b = @select(
+                u16,
+                src.a == splat(u16, 0),
+                splat(u16, 0),
+                src.b * splat(u16, 255) / @max(splat(u16, 1), src.a),
+            ),
+            .a = src.a,
+        };
+    }
+};

--- a/src/internal/util.zig
+++ b/src/internal/util.zig
@@ -77,7 +77,7 @@ pub fn gather(slice: anytype, index: anytype) @Vector(
 }
 
 /// Short-hand splatted f32 zero values, used in multiple places.
-pub const zero_float_vec: @Vector(vector_length, f32) = @splat(0.0);
+pub const zero_float_vec = splat(f32, 0.0);
 
 /// Short-hand splatted color zero values, used in multiple places.
 pub const zero_color_vec: [vector_length]colorpkg.Color = zero_color_vec: {


### PR DESCRIPTION
At long last, we are nearing the release of 0.6.0!

This PR just does some housekeeping, namely on the `color` package. I'm removing all of the vector functionality out for the time being and making it internal. This was supposed to be internal for the most part anyway, but I had to expose a bunch of it as we needed it in the compositor.

Aside from this, there's just some minor bits like consolidating some uses of RGBA16 vectors and helper cleanup.
