### PR TITLE
surface: ensure ImageSurface.init alloc correctly widens dimensions

### DIFF
--- a/src/surface.zig
+++ b/src/surface.zig
@@ -345,7 +345,9 @@ pub fn ImageSurface(comptime T: type) type {
             if (width < 0) return error.InvalidWidth;
             if (height < 0) return error.InvalidHeight;
 
-            const buf = try alloc.alloc(T, @intCast(height * width));
+            const h_usize: usize = @intCast(height);
+            const w_usize: usize = @intCast(width);
+            const buf = try alloc.alloc(T, h_usize * w_usize);
             return initBuffer(buf, width, height, initial_px_);
         }
 
@@ -490,7 +492,10 @@ pub fn ImageSurface(comptime T: type) type {
         /// safety-checked undefined behavior.
         pub fn paintStride(self: *ImageSurface(T), x: i32, y: i32, len: usize, px: pixel.Pixel) void {
             if (x < 0 or y < 0 or x >= self.width or y >= self.height) return;
-            const start: usize = @intCast(self.width * y + x);
+            const w_usize: usize = @intCast(self.width);
+            const y_usize: usize = @intCast(y);
+            const x_usize: usize = @intCast(x);
+            const start = w_usize * y_usize + x_usize;
             @memset(self.buf[start .. start + len], T.fromPixel(px));
         }
     };
@@ -718,7 +723,10 @@ pub fn PackedImageSurface(comptime T: type) type {
             // individually set, if they exist.
             const src_px = T.fromPixel(px);
             const scale = 8 / @bitSizeOf(T);
-            const start: usize = @intCast(self.width * y + x);
+            const w_usize: usize = @intCast(self.width);
+            const y_usize: usize = @intCast(y);
+            const x_usize: usize = @intCast(x);
+            const start = w_usize * y_usize + x_usize;
             const end = (start + len);
             const slice_start: usize = start / scale;
             const slice_end: usize = end / scale;


### PR DESCRIPTION
This ensures that some dimensions that were not widened during compositing and surface allocation (`ImageSurface` allocation particularly) are now properly done.

Note that this was (unintentionally) limiting memory that could be allocated for `ImageSurfaces` to ~2GB, and now this limitation is gone, so folks should understand that and be careful. :slightly_smiling_face: 

Note that in applications where this is likely to come up (rendering large surface areas with AA), there's likely improvements that can be made here, although they are outside the scope of this small fix.