### PR TITLE
Polygon: assert on finite points on plot and plotReverse

### DIFF
--- a/src/internal/Polygon.zig
+++ b/src/internal/Polygon.zig
@@ -37,6 +37,7 @@ pub fn plot(
     point: Point,
     before_: ?*CornerList.Node,
 ) mem.Allocator.Error!void {
+    debug.assert(math.isFinite(point.x) and math.isFinite(point.y));
     const n = try alloc.create(CornerList.Node);
 
     const scaled: Point = .{
@@ -53,6 +54,7 @@ pub fn plot(
 /// Like plot, but adds points in the reverse direction (i.e., at the start of
 /// the polygon instead of the end.
 pub fn plotReverse(self: *Polygon, alloc: mem.Allocator, point: Point) mem.Allocator.Error!void {
+    debug.assert(math.isFinite(point.x) and math.isFinite(point.y));
     const n = try alloc.create(CornerList.Node);
 
     const scaled: Point = .{


### PR DESCRIPTION
Every now and then we catch a degenerate case that generates NaN/Inf point values, which are currently a bit hard to track down because they're usually caught during rasterization, when the floating-point value is cast to integer. By this point, the polygon is fully "built" and the exact point where it happens is lost.

Hence, this is being added just as a safety/debugging catch-all to make sure no NaNs/Infs make it into a polygon at plot-time, which should make these cases easier to track.