### PR TITLE
painter: validate that polygon lies within surface before compositing

### DIFF
--- a/src/internal/PolygonList.zig
+++ b/src/internal/PolygonList.zig
@@ -9,11 +9,15 @@ const std = @import("std");
 const debug = @import("std").debug;
 const math = @import("std").math;
 const mem = @import("std").mem;
+const testing = @import("std").testing;
 
 const FillRule = @import("../options.zig").FillRule;
 const Polygon = @import("Polygon.zig");
 const Point = @import("Point.zig");
 const edge_buffer_size = @import("../painter.zig").edge_buffer_size;
+
+const runCases = @import("util.zig").runCases;
+const TestingError = @import("util.zig").TestingError;
 
 polygons: std.SinglyLinkedList(Polygon) = .{},
 start: Point = .{ .x = 0, .y = 0 },
@@ -45,6 +49,278 @@ pub fn prepend(self: *PolygonList, alloc: mem.Allocator, poly: Polygon) mem.Allo
         if (self.end.x < poly.end.x) self.end.x = poly.end.x;
         if (self.end.y < poly.end.y) self.end.y = poly.end.y;
     }
+}
+
+/// Returns true if our polygon list is somewhere within the box starting at
+/// (0,0) with the width box_width and the height box_height. Used to check if
+/// we should actually proceed with drawing.
+pub fn inBox(self: *const PolygonList, scale: f64, box_width: i32, box_height: i32) bool {
+    if (!math.isFinite(self.start.x) or !math.isFinite(self.start.y) or
+        !math.isFinite(self.end.x) or !math.isFinite(self.end.y))
+    {
+        @panic("invalid polygon dimensions. this is a bug, please report it");
+    }
+
+    if (!math.isFinite(scale) or scale < 1.0) {
+        @panic("invalid value for scale. this is a bug, please report it");
+    }
+
+    if (box_width < 1 or box_height < 1) {
+        @panic("invalid box width or height. this is a bug, please report it");
+    }
+
+    // Round our polygon to the appropriate dimensions. For scanline fill, we
+    // make sure to push our our box so the whole of the polygon fits in
+    // the box.
+    const poly_start_x: i32 = @intFromFloat(@floor(self.start.x / scale));
+    const poly_start_y: i32 = @intFromFloat(@floor(self.start.y / scale));
+    const poly_end_x: i32 = @intFromFloat(@ceil(self.end.x / scale));
+    const poly_end_y: i32 = @intFromFloat(@ceil(self.end.y / scale));
+
+    // Our polygon width and height
+    const poly_width: i32 = poly_end_x - poly_start_x;
+    const poly_height: i32 = poly_end_y - poly_start_y;
+
+    // If this happens, there's an error in our polygon plotting.
+    if (poly_width < 0 or poly_height < 0) {
+        @panic("negative polygon width or height. this is a bug, please report it");
+    }
+
+    // If one of our width or height are zero, nothing drawable was
+    // ultimately plotted, possibly a degenerate case.
+    if (poly_width == 0 or poly_height == 0) {
+        return false;
+    }
+
+    // Check the upper-left of our drawing area to make sure, that in the case
+    // of negative start offsets, we actually reach into the surface. If we
+    // don't (i.e., if it's not wide or high enough), we're not in the box.
+    if (poly_start_x + poly_width < 0 or poly_start_y + poly_height < 0) {
+        return false;
+    }
+
+    // Finally, if our start co-ordinates are outside the right or upper
+    // bounds of the surface, we're not in the box.
+    if (poly_start_x >= box_width or poly_start_y >= box_height) {
+        return false;
+    }
+
+    // We're in the box.
+    return true;
+}
+
+test "PolygonList.inBox" {
+    const name = "PolygonList.inBox";
+    const cases = [_]struct {
+        name: []const u8,
+        polygon_list: PolygonList,
+        scale: f64,
+        box_width: i32,
+        box_height: i32,
+        expected: bool,
+    }{
+        .{
+            .name = "basic",
+            .polygon_list = .{ .start = .{ .x = 10.0, .y = 10.0 }, .end = .{ .x = 20.0, .y = 20.0 } },
+            .scale = 1.0,
+            .box_height = 30,
+            .box_width = 30,
+            .expected = true,
+        },
+        .{
+            .name = "overlap, upper",
+            .polygon_list = .{ .start = .{ .x = 2.5, .y = -5.0 }, .end = .{ .x = 7.5, .y = 5.0 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = true,
+        },
+        .{
+            .name = "overlap, lower",
+            .polygon_list = .{ .start = .{ .x = 2.5, .y = 5.0 }, .end = .{ .x = 7.5, .y = 15.0 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = true,
+        },
+        .{
+            .name = "overlap, left",
+            .polygon_list = .{ .start = .{ .x = -5.0, .y = 2.5 }, .end = .{ .x = 5.0, .y = 7.5 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = true,
+        },
+        .{
+            .name = "overlap, right",
+            .polygon_list = .{ .start = .{ .x = 5.0, .y = 2.5 }, .end = .{ .x = 15.0, .y = 7.5 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = true,
+        },
+        .{
+            .name = "overlap, upper left",
+            .polygon_list = .{ .start = .{ .x = -5.0, .y = -5.0 }, .end = .{ .x = 5.0, .y = 5.0 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = true,
+        },
+        .{
+            .name = "overlap, upper right",
+            .polygon_list = .{ .start = .{ .x = 5.0, .y = -5.0 }, .end = .{ .x = 15.0, .y = 5.0 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = true,
+        },
+        .{
+            .name = "overlap, lower left",
+            .polygon_list = .{ .start = .{ .x = -5.0, .y = 5.0 }, .end = .{ .x = 5.0, .y = 15.0 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = true,
+        },
+        .{
+            .name = "overlap, lower right",
+            .polygon_list = .{ .start = .{ .x = 5.0, .y = 5.0 }, .end = .{ .x = 15.0, .y = 15.0 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = true,
+        },
+        .{
+            .name = "OOB, upper",
+            .polygon_list = .{ .start = .{ .x = 2.5, .y = -15.0 }, .end = .{ .x = 7.5, .y = -5.0 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = false,
+        },
+        .{
+            .name = "OOB, lower",
+            .polygon_list = .{ .start = .{ .x = 2.5, .y = 15.0 }, .end = .{ .x = 7.5, .y = 25.0 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = false,
+        },
+        .{
+            .name = "OOB, left",
+            .polygon_list = .{ .start = .{ .x = -15.0, .y = 2.5 }, .end = .{ .x = -5.0, .y = 7.5 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = false,
+        },
+        .{
+            .name = "OOB, right",
+            .polygon_list = .{ .start = .{ .x = 15.0, .y = 2.5 }, .end = .{ .x = 25.0, .y = 7.5 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = false,
+        },
+        .{
+            .name = "OOB, upper left",
+            .polygon_list = .{ .start = .{ .x = -20.0, .y = -20.0 }, .end = .{ .x = -10.0, .y = -10.0 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = false,
+        },
+        .{
+            .name = "OOB, upper right",
+            .polygon_list = .{ .start = .{ .x = 20.0, .y = -20.0 }, .end = .{ .x = 30.0, .y = -10.0 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = false,
+        },
+        .{
+            .name = "OOB, lower left",
+            .polygon_list = .{ .start = .{ .x = -20.0, .y = 20.0 }, .end = .{ .x = -10.0, .y = 30.0 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = false,
+        },
+        .{
+            .name = "OOB, lower right",
+            .polygon_list = .{ .start = .{ .x = 20.0, .y = 20.0 }, .end = .{ .x = 30.0, .y = 30.0 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = false,
+        },
+        .{
+            .name = "scale",
+            .polygon_list = .{ .start = .{ .x = 20.0, .y = 20.0 }, .end = .{ .x = 60.0, .y = 60.0 } },
+            .scale = 4.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = true,
+        },
+        .{
+            .name = "degenerate x axis",
+            .polygon_list = .{ .start = .{ .x = 5.0, .y = 2.5 }, .end = .{ .x = 5.0, .y = 7.5 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = false,
+        },
+        .{
+            .name = "degenerate y axis",
+            .polygon_list = .{ .start = .{ .x = 2.5, .y = 5.0 }, .end = .{ .x = 7.5, .y = 5.0 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = false,
+        },
+        .{
+            .name = "rounding into upper left, x-axis",
+            .polygon_list = .{ .start = .{ .x = -2.0, .y = -2.0 }, .end = .{ .x = -0.75, .y = 0.0 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = true,
+        },
+        .{
+            .name = "rounding into upper left, y-axis",
+            .polygon_list = .{ .start = .{ .x = -2.0, .y = -2.0 }, .end = .{ .x = 0.0, .y = -0.75 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = true,
+        },
+        .{
+            .name = "rounding into lower right, x-axis",
+            .polygon_list = .{ .start = .{ .x = 9.5, .y = 9.0 }, .end = .{ .x = 11, .y = 11 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = true,
+        },
+        .{
+            .name = "rounding into lower right, y-axis",
+            .polygon_list = .{ .start = .{ .x = 9.0, .y = 9.5 }, .end = .{ .x = 11, .y = 11 } },
+            .scale = 1.0,
+            .box_height = 10,
+            .box_width = 10,
+            .expected = true,
+        },
+    };
+    const TestFn = struct {
+        fn f(tc: anytype) TestingError!void {
+            try testing.expectEqualDeep(
+                tc.expected,
+                tc.polygon_list.inBox(tc.scale, tc.box_height, tc.box_width),
+            );
+        }
+    };
+    try runCases(name, cases, TestFn.f);
 }
 
 pub const EdgeListIterator = struct {

--- a/src/painter.zig
+++ b/src/painter.zig
@@ -281,6 +281,12 @@ fn paintDirect(
     operator: compositor.Operator,
     precision: compositor.Precision,
 ) PaintError!void {
+    // Do an initial check to see if our polygon is within the surface, if it
+    // isn't, it's a no-op.
+    if (!polygons.inBox(1.0, surface.getWidth(), surface.getHeight())) {
+        return;
+    }
+
     const bounded = operator.isBounded();
     // We need to check to see if we need to override the precision as we don't
     // use the surface compositor here
@@ -385,6 +391,12 @@ fn paintComposite(
     operator: compositor.Operator,
     precision: compositor.Precision,
 ) PaintError!void {
+    // Do an initial check to see if our polygon is within the surface, if it
+    // isn't, it's a no-op.
+    if (!polygons.inBox(scale, surface.getWidth(), surface.getHeight())) {
+        return;
+    }
+
     // This math expects integer scaling.
     debug.assert(@floor(scale) == scale);
     const i_scale: i32 = @intFromFloat(scale);

--- a/src/z2d.zig
+++ b/src/z2d.zig
@@ -107,5 +107,6 @@ test {
     @import("std").testing.refAllDecls(@This());
     _ = @import("internal/fill_plotter.zig");
     _ = @import("internal/stroke_plotter.zig");
+    _ = @import("internal/PolygonList.zig");
     _ = @import("static_path.zig");
 }


### PR DESCRIPTION
This is the start of some validation work that I am undertaking to make sure edge cases are better validated against.

The first one is a fairly simple one in that we now will check to make sure that a polygon actually lies within the surface in some respect (in full, or overlapping) before drawing. Not only does this provide better protection against these kinds of cases, it skips unnecessary work in some cases, like in the event the polygon is adequately y-aligned but still outside on the x-axis.