### PR TITLE
internal: usize/unsigned cleanups, arc bugfix

### DIFF
--- a/src/internal/color_vector.zig
+++ b/src/internal/color_vector.zig
@@ -163,7 +163,9 @@ pub fn fromDitherVec(
     };
     const scale = splat(f32, 1.0 / @as(
         f32,
-        @floatFromInt((@as(usize, 1) << dither.scale) - 1),
+        // Note: dither.scale being u4 limits this value to +65535
+        // ((1 << 15) - 1)
+        @floatFromInt((@as(i32, 1) << dither.scale) - 1),
     ));
     return .{
         .r = apply_dither(rgba.r, m, scale),

--- a/src/internal/dashed_plotter.zig
+++ b/src/internal/dashed_plotter.zig
@@ -87,7 +87,6 @@ const Plotter = struct {
 
     pen: ?Pen, // pen (lazy-initialized)
 
-    idx: usize = 0, // node index
     points: PointBuffer = .{}, // point buffer (initial and join points)
     clockwise_: ?bool = null, // clockwise state
 
@@ -100,8 +99,8 @@ const Plotter = struct {
     initial_polygon: union(enum) { none: void, off: Point, on: InitialPolygon } = .{ .none = {} },
 
     fn run(self: *Plotter) Error!void {
-        while (self.idx < self.nodes.len) : (self.idx += 1) {
-            switch (self.nodes[self.idx]) {
+        for (0..self.nodes.len) |idx| {
+            switch (self.nodes[idx]) {
                 .move_to => |n| try self.runMoveTo(n),
                 .line_to => |n| try self.runLineTo(n),
                 .curve_to => |n| try self.runCurveTo(n),

--- a/src/internal/fill_plotter.zig
+++ b/src/internal/fill_plotter.zig
@@ -137,7 +137,7 @@ test "degenerate line_to" {
     var result = try plot(alloc, nodes.items, 1, 0.1);
     defer result.deinit(alloc);
     try testing.expectEqual(1, result.polygons.len());
-    var corners_len: usize = 0;
+    var corners_len: i32 = 0;
     var corners: std.ArrayListUnmanaged(Point) = .{};
     defer corners.deinit(alloc);
     var next_: ?*Polygon.CornerList.Node = result.polygons.first.?.findLast().data.corners.first;

--- a/src/internal/stroke_plotter.zig
+++ b/src/internal/stroke_plotter.zig
@@ -81,7 +81,6 @@ const Plotter = struct {
 
     pen: ?Pen, // pen (lazy-initialized)
 
-    idx: usize = 0, // node index
     points: PointBuffer = .{}, // point buffer (initial and join points)
     clockwise_: ?bool = null, // clockwise state
 
@@ -90,8 +89,8 @@ const Plotter = struct {
     poly_inner: Polygon, // Current polygon (inner)
 
     fn run(self: *Plotter) Error!void {
-        while (self.idx < self.nodes.len) : (self.idx += 1) {
-            switch (self.nodes[self.idx]) {
+        for (0..self.nodes.len) |idx| {
+            switch (self.nodes[idx]) {
                 .move_to => |n| try self.runMoveTo(n),
                 .line_to => |n| try self.runLineTo(n),
                 .curve_to => |n| try self.runCurveTo(n),
@@ -586,7 +585,7 @@ test "assert ok: degenerate moveto -> lineto, then good lineto" {
         });
         defer result.deinit(alloc);
         try testing.expectEqual(1, result.polygons.len());
-        var corners_len: usize = 0;
+        var corners_len: i32 = 0;
         var next_: ?*Polygon.CornerList.Node = result.polygons.first.?.findLast().data.corners.first;
         while (next_) |n| {
             corners_len += 1;
@@ -617,7 +616,7 @@ test "assert ok: degenerate moveto -> lineto, then good lineto" {
         });
         defer result.deinit(alloc);
         try testing.expectEqual(1, result.polygons.len());
-        var corners_len: usize = 0;
+        var corners_len: i32 = 0;
         var next_: ?*Polygon.CornerList.Node = result.polygons.first.?.findLast().data.corners.first;
         while (next_) |n| {
             corners_len += 1;
@@ -659,7 +658,7 @@ test "slope difference below epsilon does not produce NaN" {
         });
         defer result.deinit(alloc);
         try testing.expectEqual(1, result.polygons.len());
-        var idx: usize = 0;
+        var idx: i32 = 0;
         var next_: ?*Polygon.CornerList.Node = result.polygons.first.?.findLast().data.corners.first;
         while (next_) |n| {
             if (!math.isFinite(n.data.x) or !math.isFinite(n.data.y)) {


### PR DESCRIPTION
* Cleans up some use of unsigned variables when they are unnecessary or should not be used. This is reflective of a more general move away from usize and unsigned vars in general.

* Moves some stuff away from while loops to for loops, and removes some unnecessary fields in iterators as well.

* Also corrects a bug in an edge case catcher in `arc_max_angle_for_tolerance_normalized`, looks like when this was ported over from Cairo, we forgot to negate the testing clause in a `do..while` loop, now that this is a for loop it was a lot easier to catch as being bad. This is not getting hit in our normal test cases which is probably why it got missed.