### PR TITLE
Updated to build under zig v0.15.0 changes to linked lists

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,7 @@
     .name = .z2d,
     .version = "0.7.0",
     .fingerprint = 0x188c5a41eff938f,
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.0-dev.768+cffa98eef",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/internal/dashed_plotter.zig
+++ b/src/internal/dashed_plotter.zig
@@ -375,7 +375,7 @@ const Plotter = struct {
         // stroke.
         //
         // All other zero-length strokes draw nothing.
-        debug.assert(self.poly_inner.corners.len == 0); // should have not been used
+        debug.assert(self.poly_inner.corners.len() == 0); // should have not been used
         switch (self.opts.cap_mode) {
             .round => {
                 // Just plot off all of the pen's vertices, no need to

--- a/src/internal/fill_plotter.zig
+++ b/src/internal/fill_plotter.zig
@@ -38,7 +38,7 @@ pub fn plot(
                 if (current_polygon) |poly| {
                     // Only append this polygon if it's useful (has more than 2
                     // corners). Otherwise, get rid of it.
-                    if (poly.corners.len > 2) {
+                    if (poly.corners.len() > 2) {
                         try result.prepend(alloc, poly);
                     } else {
                         poly.deinit(alloc);
@@ -140,11 +140,13 @@ test "degenerate line_to" {
     var corners_len: i32 = 0;
     var corners: std.ArrayListUnmanaged(Point) = .{};
     defer corners.deinit(alloc);
-    var next_: ?*Polygon.CornerList.Node = result.polygons.first.?.findLast().data.corners.first;
-    while (next_) |n| {
+    const poly: *PolygonList.PolygonListItem = @fieldParentPtr("node", result.polygons.first.?.findLast());
+    var next_: ?*std.DoublyLinkedList.Node = poly.data.corners.first;
+    while (next_) |node| {
+        const n: *Polygon.CornerListItem = @fieldParentPtr("node", node);
         try corners.append(alloc, n.data);
         corners_len += 1;
-        next_ = n.next;
+        next_ = node.next;
     }
     try testing.expectEqual(3, corners_len);
     try testing.expectEqualSlices(Point, &.{

--- a/src/internal/stroke_plotter.zig
+++ b/src/internal/stroke_plotter.zig
@@ -208,7 +208,7 @@ const Plotter = struct {
         //
         // Note that we draw rectangles/squares for dashed lines, see this
         // function in the dashed plotter for more details.
-        debug.assert(self.poly_inner.corners.len == 0); // should have not been used
+        debug.assert(self.poly_inner.corners.len() == 0); // should have not been used
         if (self.opts.cap_mode == .round) {
             // Just plot off all of the pen's vertices, no need to
             // determine a subset as we're doing a 360-degree plot.
@@ -246,7 +246,7 @@ const Plotter = struct {
 pub fn plotSingle(T: type, self: *T, start: Point, end: Point) Error!void {
     // Single-segment line. This can be drawn off of
     // our start line caps.
-    debug.assert(self.poly_inner.corners.len == 0); // should have not been used
+    debug.assert(self.poly_inner.corners.len() == 0); // should have not been used
     const cap_points = Face.init(
         start,
         end,
@@ -599,10 +599,11 @@ test "assert ok: degenerate moveto -> lineto, then good lineto" {
         defer result.deinit(alloc);
         try testing.expectEqual(1, result.polygons.len());
         var corners_len: i32 = 0;
-        var next_: ?*Polygon.CornerList.Node = result.polygons.first.?.findLast().data.corners.first;
-        while (next_) |n| {
+        const poly: *PolygonList.PolygonListItem = @fieldParentPtr("node", result.polygons.first.?.findLast());
+        var next_: ?*Polygon.CornerList.Node = poly.data.corners.first;
+        while (next_) |node| {
             corners_len += 1;
-            next_ = n.next;
+            next_ = node.next;
         }
         try testing.expectEqual(4, corners_len);
     }
@@ -630,7 +631,8 @@ test "assert ok: degenerate moveto -> lineto, then good lineto" {
         defer result.deinit(alloc);
         try testing.expectEqual(1, result.polygons.len());
         var corners_len: i32 = 0;
-        var next_: ?*Polygon.CornerList.Node = result.polygons.first.?.findLast().data.corners.first;
+        const poly: *PolygonList.PolygonListItem = @fieldParentPtr("node", result.polygons.first.?.findLast());
+        var next_: ?*Polygon.CornerList.Node = poly.data.corners.first;
         while (next_) |n| {
             corners_len += 1;
             next_ = n.next;
@@ -672,14 +674,16 @@ test "slope difference below epsilon does not produce NaN" {
         defer result.deinit(alloc);
         try testing.expectEqual(1, result.polygons.len());
         var idx: i32 = 0;
-        var next_: ?*Polygon.CornerList.Node = result.polygons.first.?.findLast().data.corners.first;
-        while (next_) |n| {
+        const poly: *PolygonList.PolygonListItem = @fieldParentPtr("node", result.polygons.first.?.findLast());
+        var next_: ?*Polygon.CornerList.Node = poly.data.corners.first;
+        while (next_) |node| {
+            const n: *Polygon.CornerListItem = @fieldParentPtr("node", node);
             if (!math.isFinite(n.data.x) or !math.isFinite(n.data.y)) {
                 debug.print("Non-finite value found at index {}, data: {}\n", .{ idx, n.data });
                 return error.TestExpectedFinite;
             }
             idx += 1;
-            next_ = n.next;
+            next_ = node.next;
         }
     }
 }


### PR DESCRIPTION
I was doing some work to get dvui working under zig v15 and needed to update z2d to do that.
If you aren't interested in these changes yet, then no issues.
I wasn't too sure about the `self.corners.concatByMoving(@constCast(&other.corners));`
