### PR TITLE
Polygon: re-introduce xEdgesForY i30 clamping

### DIFF
--- a/src/internal/Polygon.zig
+++ b/src/internal/Polygon.zig
@@ -260,9 +260,11 @@ pub fn xEdgesForY(
     for (self.edges.items) |current_edge| {
         if (current_edge.top < line_y_middle and current_edge.bottom >= line_y_middle) {
             try edge_list.append(alloc, .{
-                .x = @intFromFloat(
+                .x = @intFromFloat(math.clamp(
                     @round(current_edge.x_start + current_edge.x_inc * (line_y_middle - current_edge.top)),
-                ),
+                    0,
+                    math.maxInt(XEdge.X),
+                )),
                 .dir = current_edge.dir,
             });
         }
@@ -679,4 +681,15 @@ test "Polygon.inBox" {
         }
     };
     try runCases(name, cases, TestFn.f);
+}
+
+test "xEdgesForY, prevent i30 overflow" {
+    const alloc = testing.allocator;
+    var polygon: Polygon = .{};
+    defer polygon.deinit(alloc);
+    try polygon.addEdge(alloc, .{ .x = 600000100, .y = 600000100 }, .{ .x = 600000050, .y = 600000200 });
+    try polygon.addEdge(alloc, .{ .x = 600000050, .y = 600000200 }, .{ .x = 600000000, .y = 600000100 });
+    // Don't need a result here, just needs to actually work and not overflow
+    var x_edges = try polygon.xEdgesForY(alloc, 600000150, .non_zero);
+    defer x_edges.deinit(alloc);
 }


### PR DESCRIPTION
When calculating, the x-edges returned by the (previously named) `edgesForY` method would be clamped to `i30` (or should have been, after reviewing the code I'm not too sure if this would have actually worked). This is because we store the edges in a small stack-based buffer (512 bytes) that also includes the direction, and we want to make sure that there is enough room for 16 items here so these values are packed. However, the clamping was lost in #128.

This re-introduces it and ensures that the clamping happens correctly before conversion, which was the thing that was not happening even before #128. A unit test is also added that will trigger safety-checked UB if the clamping is not happening.