### PR TITLE
painter: ditch FBA for x-edge allocation

### DIFF
--- a/src/internal/Polygon.zig
+++ b/src/internal/Polygon.zig
@@ -248,8 +248,7 @@ pub fn xEdgesForY(
 ) mem.Allocator.Error!XEdgeListIterator {
     if (self.edges.items.len == 0) return .{};
 
-    const edge_list_capacity = edge_buffer_size / @sizeOf(XEdge);
-    var edge_list = try std.ArrayListUnmanaged(XEdge).initCapacity(alloc, edge_list_capacity);
+    var edge_list: std.ArrayListUnmanaged(XEdge) = .empty;
     defer edge_list.deinit(alloc);
 
     // We take our line measurements at the middle of the line; this helps

--- a/src/painter.zig
+++ b/src/painter.zig
@@ -28,15 +28,6 @@ const InternalError = @import("internal/InternalError.zig").InternalError;
 const supersample_scale = @import("surface.zig").supersample_scale;
 const compositor = @import("compositor.zig");
 
-/// The size of the stack buffer portion of the allocator used to store
-/// discovered edges on a given scanline during rasterization. The value is in
-/// bytes and is reset per scanline. It is further divided up to various parts
-/// of the edge discovery process. If this is exhausted, allocation falls back
-/// to the heap (or whatever other allocator was passed into fill or stroke).
-///
-/// This value is not modifiable at this time.
-pub const edge_buffer_size = 512;
-
 pub const FillOpts = struct {
     /// The anti-aliasing mode to use with the fill operation.
     anti_aliasing_mode: options.AntiAliasMode = .default,
@@ -308,19 +299,22 @@ fn paintDirect(
     const start_scanline: i32 = math.clamp(poly_start_y, 0, sfc_height - 1);
     const end_scanline: i32 = math.clamp(poly_end_y, start_scanline, sfc_height - 1);
 
+    // Make an ArenaAllocator for our edges, this allows us to re-use the same
+    // memory after every scanline by simply resetting the arena.
+    var edge_arena = heap.ArenaAllocator.init(alloc);
+    defer edge_arena.deinit();
+    const edge_alloc = edge_arena.allocator();
+
     // Note that we have to add 1 to the end scanline here as our start -> end
     // boundaries above only account for+clamp to the last line to be scanned,
     // so our len is end + 1. This helps correct for scenarios like small
     // polygons laying on edges, or very small surfaces (e.g., 1 pixel high).
     for (@max(0, start_scanline)..@max(0, end_scanline) + 1) |y_u| {
+        defer {
+            _ = edge_arena.reset(.retain_capacity);
+        }
         const y: i32 = @intCast(y_u);
 
-        // Make a small FBA for edge caches, falling back to the passed in
-        // allocator if we need to. This should be more than enough to do most
-        // cases, but we can't guarantee it and we don't necessarily want to
-        // blow up the stack.
-        var edge_stack_fallback = heap.stackFallback(edge_buffer_size, alloc);
-        const edge_alloc = edge_stack_fallback.get();
         var edge_list = try polygons.xEdgesForY(edge_alloc, @floatFromInt(y), fill_rule);
         defer edge_list.deinit(edge_alloc);
 
@@ -473,15 +467,17 @@ fn paintComposite(
         );
         errdefer mask_sfc_scaled.deinit(alloc);
 
-        for (0..@max(0, mask_height)) |y_u| {
-            const y: i32 = @intCast(y_u);
+        // Make an ArenaAllocator for our edges, this allows us to re-use the
+        // same memory after every scanline by simply resetting the arena.
+        var edge_arena = heap.ArenaAllocator.init(alloc);
+        defer edge_arena.deinit();
+        const edge_alloc = edge_arena.allocator();
 
-            // Make a small FBA for edge caches, falling back to the passed in
-            // allocator if we need to. This should be more than enough to do
-            // most cases, but we can't guarantee it and we don't necessarily
-            // want to blow up the stack.
-            var edge_stack_fallback = heap.stackFallback(edge_buffer_size, alloc);
-            const edge_alloc = edge_stack_fallback.get();
+        for (0..@max(0, mask_height)) |y_u| {
+            defer {
+                _ = edge_arena.reset(.retain_capacity);
+            }
+            const y: i32 = @intCast(y_u);
 
             // Our polygon co-ordinates are in (scaled) device space, so when
             // we search for edges, we need to offset our mask-space scanline


### PR DESCRIPTION
This switches the FBA that we were using for x-edge allocation during the scanline fill for a simple arena wrapping the allocator that is passed in at the higher level.

This is being done so that we have more freedom in determining the data that gets passed back during x-edge calculation. Currently, we make efforts to try and fit the entirety of a single edge into a `u32` (including truncating the actual x-coordinate to an `i30`, which I want to get rid of). Future AA algorithms may require that we keep a reference back to the actual edge data (so that we can further calculate sub-scanlines during rasterization) - this will increase the amount of data we need to keep to at least 96 bits, and 128 if we don't pack it. This either requires more data to go on the stack, or less edges be stored.

Benchmarks have shown that the cost of removing the FBA is fairly minimal. Additionally, the use of an arena allows us to re-use the same memory every scanline, keeping the actual allocations that happen down to a minimum.