### PR TITLE
Path: lower co-ordinate limit to i24

### DIFF
--- a/src/Path.zig
+++ b/src/Path.zig
@@ -76,6 +76,12 @@ tolerance: f64 = options.default_tolerance,
 /// device space).
 transformation: Transformation = Transformation.identity,
 
+/// The limit for co-ordinates allowed in this path. Must be set to a signed
+/// integer type with an allowed maximum of i32.
+///
+/// This clamps all co-ordinates added using `moveTo`, `lineTo`, etc to the
+/// integer range. Note that changing this value has implications for
+/// anti-aliasing, and could
 /// Represents an empty `Path`.
 pub const empty: Path = .{};
 
@@ -120,8 +126,8 @@ pub fn moveTo(self: *Path, alloc: mem.Allocator, x: f64, y: f64) mem.Allocator.E
 /// exists for the point.
 pub fn moveToAssumeCapacity(self: *Path, x: f64, y: f64) void {
     const point: Point = (Point{
-        .x = clampI32(x),
-        .y = clampI32(y),
+        .x = clampI24(x),
+        .y = clampI24(y),
     }).applyTransform(self.transformation);
     // If our last operation is a move_to to this point, this is a no-op.
     // This ensures that there's no duplicates on things like explicit
@@ -172,8 +178,8 @@ pub fn lineTo(self: *Path, alloc: mem.Allocator, x: f64, y: f64) mem.Allocator.E
 pub fn lineToAssumeCapacity(self: *Path, x: f64, y: f64) void {
     if (self.current_point == null) return self.moveToAssumeCapacity(x, y);
     const point: Point = (Point{
-        .x = clampI32(x),
-        .y = clampI32(y),
+        .x = clampI24(x),
+        .y = clampI24(y),
     }).applyTransform(self.transformation);
     self.nodes.appendAssumeCapacity(.{ .line_to = .{ .point = point } });
     self.current_point = point;
@@ -241,16 +247,16 @@ fn _curveToAssumeCapacity(
     y3: f64,
 ) void {
     const p1: Point = (Point{
-        .x = clampI32(x1),
-        .y = clampI32(y1),
+        .x = clampI24(x1),
+        .y = clampI24(y1),
     }).applyTransform(self.transformation);
     const p2: Point = (Point{
-        .x = clampI32(x2),
-        .y = clampI32(y2),
+        .x = clampI24(x2),
+        .y = clampI24(y2),
     }).applyTransform(self.transformation);
     const p3: Point = (Point{
-        .x = clampI32(x3),
-        .y = clampI32(y3),
+        .x = clampI24(x3),
+        .y = clampI24(y3),
     }).applyTransform(self.transformation);
     self.nodes.appendAssumeCapacity(.{ .curve_to = .{ .p1 = p1, .p2 = p2, .p3 = p3 } });
     self.current_point = p3;
@@ -477,8 +483,8 @@ pub fn isClosed(self: *const Path) bool {
     return PathNode.isClosedNodeSet(self.nodes.items);
 }
 
-fn clampI32(x: f64) f64 {
-    return math.clamp(x, math.minInt(i32), math.maxInt(i32));
+fn clampI24(x: f64) f64 {
+    return math.clamp(x, math.minInt(i24), math.maxInt(i24));
 }
 
 test "moveTo clamped" {
@@ -496,12 +502,12 @@ test "moveTo clamped" {
         // Clamped
         var p = try initCapacity(alloc, 0);
         defer p.deinit(alloc);
-        try p.moveTo(alloc, math.minInt(i32) - 1, math.maxInt(i32) + 1);
+        try p.moveTo(alloc, math.minInt(i24) - 1, math.maxInt(i24) + 1);
         try testing.expectEqual(PathNode{
-            .move_to = .{ .point = .{ .x = math.minInt(i32), .y = math.maxInt(i32) } },
+            .move_to = .{ .point = .{ .x = math.minInt(i24), .y = math.maxInt(i24) } },
         }, p.nodes.items[0]);
-        try testing.expectEqual(Point{ .x = math.minInt(i32), .y = math.maxInt(i32) }, p.initial_point);
-        try testing.expectEqual(Point{ .x = math.minInt(i32), .y = math.maxInt(i32) }, p.current_point);
+        try testing.expectEqual(Point{ .x = math.minInt(i24), .y = math.maxInt(i24) }, p.initial_point);
+        try testing.expectEqual(Point{ .x = math.minInt(i24), .y = math.maxInt(i24) }, p.current_point);
     }
 }
 
@@ -522,12 +528,12 @@ test "lineTo clamped" {
         var p = try initCapacity(alloc, 0);
         defer p.deinit(alloc);
         try p.moveTo(alloc, 1, 1);
-        try p.lineTo(alloc, math.minInt(i32) - 1, math.maxInt(i32) + 1);
+        try p.lineTo(alloc, math.minInt(i24) - 1, math.maxInt(i24) + 1);
         try testing.expectEqual(PathNode{
-            .line_to = .{ .point = .{ .x = math.minInt(i32), .y = math.maxInt(i32) } },
+            .line_to = .{ .point = .{ .x = math.minInt(i24), .y = math.maxInt(i24) } },
         }, p.nodes.items[1]);
         try testing.expectEqual(Point{ .x = 1, .y = 1 }, p.initial_point);
-        try testing.expectEqual(Point{ .x = math.minInt(i32), .y = math.maxInt(i32) }, p.current_point);
+        try testing.expectEqual(Point{ .x = math.minInt(i24), .y = math.maxInt(i24) }, p.current_point);
     }
 }
 
@@ -554,12 +560,12 @@ test "curveTo clamped" {
         var p = try initCapacity(alloc, 0);
         defer p.deinit(alloc);
         try p.moveTo(alloc, 1, 1);
-        try p.curveTo(alloc, math.minInt(i32) - 1, math.maxInt(i32) + 1, 3, 4, 5, 6);
+        try p.curveTo(alloc, math.minInt(i24) - 1, math.maxInt(i24) + 1, 3, 4, 5, 6);
         try testing.expectEqual(PathNode{
             .curve_to = .{
                 .p1 = .{
-                    .x = math.minInt(i32),
-                    .y = math.maxInt(i32),
+                    .x = math.minInt(i24),
+                    .y = math.maxInt(i24),
                 },
                 .p2 = .{ .x = 3, .y = 4 },
                 .p3 = .{ .x = 5, .y = 6 },
@@ -567,32 +573,32 @@ test "curveTo clamped" {
         }, p.nodes.items[1]);
         try testing.expectEqual(Point{ .x = 1, .y = 1 }, p.initial_point);
         try testing.expectEqual(Point{ .x = 5, .y = 6 }, p.current_point);
-        try p.curveTo(alloc, 1, 2, math.minInt(i32) - 1, math.maxInt(i32) + 1, 5, 6);
+        try p.curveTo(alloc, 1, 2, math.minInt(i24) - 1, math.maxInt(i24) + 1, 5, 6);
         try testing.expectEqual(PathNode{
             .curve_to = .{
                 .p1 = .{ .x = 1, .y = 2 },
                 .p2 = .{
-                    .x = math.minInt(i32),
-                    .y = math.maxInt(i32),
+                    .x = math.minInt(i24),
+                    .y = math.maxInt(i24),
                 },
                 .p3 = .{ .x = 5, .y = 6 },
             },
         }, p.nodes.items[2]);
         try testing.expectEqual(Point{ .x = 1, .y = 1 }, p.initial_point);
         try testing.expectEqual(Point{ .x = 5, .y = 6 }, p.current_point);
-        try p.curveTo(alloc, 1, 2, 3, 4, math.minInt(i32) - 1, math.maxInt(i32) + 1);
+        try p.curveTo(alloc, 1, 2, 3, 4, math.minInt(i24) - 1, math.maxInt(i24) + 1);
         try testing.expectEqual(PathNode{
             .curve_to = .{
                 .p1 = .{ .x = 1, .y = 2 },
                 .p2 = .{ .x = 3, .y = 4 },
                 .p3 = .{
-                    .x = math.minInt(i32),
-                    .y = math.maxInt(i32),
+                    .x = math.minInt(i24),
+                    .y = math.maxInt(i24),
                 },
             },
         }, p.nodes.items[3]);
         try testing.expectEqual(Point{ .x = 1, .y = 1 }, p.initial_point);
-        try testing.expectEqual(Point{ .x = math.minInt(i32), .y = math.maxInt(i32) }, p.current_point);
+        try testing.expectEqual(Point{ .x = math.minInt(i24), .y = math.maxInt(i24) }, p.current_point);
     }
 }
 


### PR DESCRIPTION
This commit lowers our path co-ordinate limit to `i24` - meaning that any co-ordinate set using `moveTo`, `lineTo`, etc., will now be limited to +/-8388608.

This is something I've mulled on and off for probably as long as z2d has existed, mainly as a measure of ensuring safety in the event of changes to accommodate things like fixed-point, which has never materialized as being necessary or useful, although this may change and has not been completely exhausted as a possibility.

Before this, the limit was `i32`, which was mainly serving as a upper limit of what could ultimately be returned in the event of drawing when no anti-aliasing was being done. However, anti-aliasing *does* effectively reduce the reasonable range to +/-536870912, and the advent of MSAA raises the possibility that we could go even lower, possibly from 4x to 8x or even 16x, so possibly as low as +/-134217728. However, even at these limits I'd be very worried for things like performance or other constraints (even though we do try as hard as possible to prevent overflows and what not during rasterization calculations).

Rather than speculate over what the future holds or what the real-world scenarios look like, I've decided to take the safe route and clamp to `i24`. This provides future-proofing in the event that we use fixed point (even if it's just in a limited fashion, like during scanline rasterization, as opposed to tessellation, where if we don't necessarily benefit from integer calculations, we still benefit from the savings on the values we need to hold in memory), while also setting a reasonable, albeit still very extremely liberal, limit on the co-ordinate space, that should accommodate any foreseeable need of the library.

For some context and prior art:

* Cairo effectively clamps to `i24` (they make heavy use of 24.8 fixed point). This can be confirmed by looking at the value of CAIRO_FIXED_MAX_DOUBLE.
* I've seen some mention of Skia clamping to `i16`, but I have not 100% confirmed.
* Pixman is in a similar scenario where I've seen mentions of clamping to `i16`, but more interrogation would be needed to 100% confirm.