### PR TITLE
Context: release font on and fully invalidate on deinit

### DIFF
--- a/src/Context.zig
+++ b/src/Context.zig
@@ -13,6 +13,7 @@
 const Context = @This();
 
 const mem = @import("std").mem;
+const testing = @import("std").testing;
 
 const compositor = @import("compositor.zig");
 const options = @import("options.zig");
@@ -63,15 +64,17 @@ pub fn init(alloc: mem.Allocator, surface: *Surface) Context {
     return .{
         .alloc = alloc,
         .surface = surface,
-        .path = .{},
+        .path = .empty,
     };
 }
 
 /// Releases all resources associated with this particular context, such as the
-/// managed `Path`.
+/// managed path and any loaded font. Also invalidates the context, meaning it
+/// must not be used after this call.
 pub fn deinit(self: *Context) void {
+    self.deinitFont();
     self.path.deinit(self.alloc);
-    self.path = undefined;
+    self.* = undefined;
 }
 
 /// Releases any font data held on by the context.
@@ -643,4 +646,66 @@ fn wrapDither(self: *Context) Pattern {
             },
         },
     };
+}
+
+test "deinit after allocating path elements" {
+    const alloc = testing.allocator;
+    var sfc = try Surface.init(.image_surface_rgb, alloc, 1, 1);
+    defer sfc.deinit(alloc);
+    var context = Context.init(alloc, &sfc);
+    errdefer context.deinit();
+    try context.moveTo(10, 10);
+    try context.lineTo(20, 20);
+    try testing.expectEqual(2, context.path.nodes.items.len);
+    context.deinit();
+}
+
+test "setFontToFile, deinit" {
+    const alloc = testing.allocator;
+    var sfc = try Surface.init(.image_surface_rgb, alloc, 1, 1);
+    defer sfc.deinit(alloc);
+    var context = Context.init(alloc, &sfc);
+    errdefer context.deinit();
+    try context.setFontToFile("./src/internal/test-fonts/Inter-Regular.subset.ttf");
+    try testing.expect(context.font == .file);
+    context.deinit();
+}
+
+test "setFontToBuffer, deinit" {
+    const alloc = testing.allocator;
+    var sfc = try Surface.init(.image_surface_rgb, alloc, 1, 1);
+    defer sfc.deinit(alloc);
+    var context = Context.init(alloc, &sfc);
+    errdefer context.deinit();
+    try context.setFontToBuffer(@embedFile("./internal/test-fonts/Inter-Regular.subset.ttf"));
+    try testing.expect(context.font == .buffer);
+    context.deinit();
+}
+
+test "setFontToFile, deinitFont" {
+    const alloc = testing.allocator;
+    var sfc = try Surface.init(.image_surface_rgb, alloc, 1, 1);
+    defer sfc.deinit(alloc);
+    var context = Context.init(alloc, &sfc);
+    // NOTE: No deinit here for the context. We want to test deinitFont
+    // exclusively. Nothing else should leak as a result from this as we are
+    // de-allocating our surface and nothing is being added to the path.
+    try context.setFontToFile("./src/internal/test-fonts/Inter-Regular.subset.ttf");
+    try testing.expect(context.font == .file);
+    context.deinitFont();
+    try testing.expect(context.font == .none);
+}
+
+test "setFontToBuffer, deinitFont" {
+    const alloc = testing.allocator;
+    var sfc = try Surface.init(.image_surface_rgb, alloc, 1, 1);
+    defer sfc.deinit(alloc);
+    var context = Context.init(alloc, &sfc);
+    // NOTE: No deinit here for the context. We want to test deinitFont
+    // exclusively. Nothing else should leak as a result from this as we are
+    // de-allocating our surface and nothing is being added to the path.
+    try context.setFontToBuffer(@embedFile("./internal/test-fonts/Inter-Regular.subset.ttf"));
+    try testing.expect(context.font == .buffer);
+    context.deinitFont();
+    try testing.expect(context.font == .none);
 }


### PR DESCRIPTION
This is a 2-part commit:

* First off, font was not being released on `deinit`, this is fixed now.
* Second off, we're correcting behavior for `deinit`, we set the underlying path to `undefined` but otherwise leave a lot of other stuff in place. This completely invalidates the context to `undefined` now, a pattern we will adopt later in the rest of the codebase.