### PR TITLE
Make deinit calls more strict/correct

### DIFF
--- a/src/Font.zig
+++ b/src/Font.zig
@@ -71,6 +71,7 @@ pub fn loadBuffer(buffer: []const u8) LoadBufferError!Font {
 /// to use this with `loadBuffer`.
 pub fn deinit(self: *Font, alloc: mem.Allocator) void {
     alloc.free(self.file.buffer);
+    self.* = undefined;
 }
 
 /// Errors associated with reading font file data, generally an alias for file

--- a/src/Path.zig
+++ b/src/Path.zig
@@ -100,6 +100,7 @@ pub fn initBuffer(nodes: []PathNode) Path {
 /// after this call.
 pub fn deinit(self: *Path, alloc: mem.Allocator) void {
     self.nodes.deinit(alloc);
+    self.* = undefined;
 }
 
 /// Rests the path set, clearing all nodes and state.

--- a/src/gradient.zig
+++ b/src/gradient.zig
@@ -154,6 +154,7 @@ pub const Gradient = union(GradientType) {
         switch (self.*) {
             inline else => |*g| g.deinit(alloc),
         }
+        self.* = undefined;
     }
 
     /// Shorthand for returning the gradient as a pattern.
@@ -298,6 +299,7 @@ pub const Linear = struct {
     /// the same allocator that was used there.
     pub fn deinit(self: *Linear, alloc: mem.Allocator) void {
         self.stops.deinit(alloc);
+        self.* = undefined;
     }
 
     /// Returns this gradient as a higher-level gradient interface.
@@ -439,6 +441,7 @@ pub const Radial = struct {
     /// the same allocator that was used there.
     pub fn deinit(self: *Radial, alloc: mem.Allocator) void {
         self.stops.deinit(alloc);
+        self.* = undefined;
     }
 
     /// Returns this gradient as a higher-level gradient interface.
@@ -681,6 +684,7 @@ pub const Conic = struct {
     /// the same allocator that was used there.
     pub fn deinit(self: *Conic, alloc: mem.Allocator) void {
         self.stops.deinit(alloc);
+        self.* = undefined;
     }
 
     /// Returns this gradient as a higher-level gradient interface.
@@ -757,6 +761,7 @@ pub const Stop = struct {
         /// Releases any memory allocated using `add`.
         fn deinit(self: *List, alloc: mem.Allocator) void {
             self.l.deinit(alloc);
+            self.* = undefined;
         }
 
         /// Adds a stop with the specified offset and color. The offset will be

--- a/src/internal/Glyph.zig
+++ b/src/internal/Glyph.zig
@@ -802,6 +802,7 @@ pub const Outline = struct {
 
     pub fn deinit(self: *Outline, alloc: mem.Allocator) void {
         self.path.deinit(alloc);
+        self.* = undefined;
     }
 
     /// "Appends", or replays, the stored path within the outline on the path supplied.

--- a/src/internal/Pen.zig
+++ b/src/internal/Pen.zig
@@ -129,6 +129,7 @@ pub fn init(
 
 pub fn deinit(self: *Pen, alloc: mem.Allocator) void {
     self.vertices.deinit(alloc);
+    self.* = undefined;
 }
 
 /// Returns an iterator for the vertex range from one face to the other,

--- a/src/internal/Polygon.zig
+++ b/src/internal/Polygon.zig
@@ -31,7 +31,7 @@ extent_right: f64 = 0.0,
 
 pub fn deinit(self: *Polygon, alloc: mem.Allocator) void {
     self.edges.deinit(alloc);
-    self.edges = .{};
+    self.* = undefined;
 }
 
 pub fn addEdge(
@@ -261,7 +261,7 @@ pub const Contour = struct {
             node_ = node.next;
             alloc.destroy(node);
         }
-        self.corners = .{};
+        self.* = undefined;
     }
 
     /// Plots a point on the contour. If before is specified, the point is

--- a/src/internal/sparse_coverage.zig
+++ b/src/internal/sparse_coverage.zig
@@ -71,12 +71,10 @@ pub const SparseCoverageBuffer = struct {
 
     pub fn deinit(self: *SparseCoverageBuffer, alloc: mem.Allocator) void {
         alloc.free(self.values);
-        self.values = undefined;
         switch (self.lengths) {
             inline else => |l| alloc.free(l),
         }
-        self.lengths = undefined;
-        self.len = undefined;
+        self.* = undefined;
     }
 
     pub fn reset(self: *SparseCoverageBuffer) void {

--- a/src/surface.zig
+++ b/src/surface.zig
@@ -181,6 +181,7 @@ pub const Surface = union(SurfaceType) {
                 s.deinit(alloc);
             },
         }
+        self.* = undefined;
     }
 
     /// Downsamples the image, using simple pixel averaging. The surface is
@@ -387,6 +388,7 @@ pub fn ImageSurface(comptime T: type) type {
         /// this is called.
         pub fn deinit(self: *ImageSurface(T), alloc: mem.Allocator) void {
             alloc.free(self.buf);
+            self.* = undefined;
         }
 
         /// Downsamples the image, using simple pixel averaging. The surface is
@@ -599,6 +601,7 @@ pub fn PackedImageSurface(comptime T: type) type {
         /// this is called.
         pub fn deinit(self: *PackedImageSurface(T), alloc: mem.Allocator) void {
             alloc.free(self.buf);
+            self.* = undefined;
         }
 
         /// Downsamples the image, using simple pixel averaging. The surface is


### PR DESCRIPTION
The correct `deinit` convention should be: release resources, invalidate memory. We are currently not following the latter part of that convention. This fixes that, and sets the expectation for future `deinit` calls. :slightly_smiling_face: 

Note that there's `Context.deinitFont` that does a "pseudo-invalidation" - I've considered renaming this function (briefly, while I'm typing this :stuck_out_tongue_winking_eye:), and I think it's fine as-is. It *can* be considered an invalidation as it sets the in-use font to `.none`, which makes using text functions invalid until another font is set. That's following the spirit of the convention, as far as I'm concerned.