### PR TITLE
pixel: remove copyStride and other unused code

### DIFF
--- a/src/surface.zig
+++ b/src/surface.zig
@@ -289,18 +289,6 @@ pub const Surface = union(SurfaceType) {
         };
     }
 
-    /// Puts the supplied stride at `(x, y)`, proceeding for its full length.
-    ///
-    /// Out-of-range start co-ordinates cause a no-op.
-    ///
-    /// It's expected that src will fit; overruns are safety-checked undefined
-    /// behavior.
-    pub fn putStride(self: *Surface, x: i32, y: i32, src: pixel.Stride) void {
-        return switch (self.*) {
-            inline else => |*s| s.putStride(x, y, src),
-        };
-    }
-
     /// Replaces the surface with the supplied pixel.
     pub fn paintPixel(self: *Surface, px: pixel.Pixel) void {
         return switch (self.*) {
@@ -492,18 +480,6 @@ pub fn ImageSurface(comptime T: type) type {
         pub fn putPixel(self: *ImageSurface(T), x: i32, y: i32, px: pixel.Pixel) void {
             if (x < 0 or y < 0 or x >= self.width or y >= self.height) return;
             self.buf[@max(0, @as(isize, self.width) * y + x)] = T.fromPixel(px);
-        }
-
-        /// Puts the supplied stride at `(x, y)`, proceeding for its full
-        /// length.
-        ///
-        /// Out-of-range start co-ordinates cause a no-op.
-        ///
-        /// It's expected that src will fit; overruns are
-        /// safety-checked undefined behavior.
-        pub fn putStride(self: *ImageSurface(T), x: i32, y: i32, src: pixel.Stride) void {
-            if (x < 0 or y < 0 or x >= self.width or y >= self.height) return;
-            self.getStride(x, y, src.pxLen()).copy(src);
         }
 
         /// Replaces the surface with the supplied pixel.
@@ -717,18 +693,6 @@ pub fn PackedImageSurface(comptime T: type) type {
         pub fn putPixel(self: *PackedImageSurface(T), x: i32, y: i32, px: pixel.Pixel) void {
             if (x < 0 or y < 0 or x >= self.width or y >= self.height) return;
             self._set(@max(0, @as(isize, self.width) * y + x), T.fromPixel(px));
-        }
-
-        /// Puts the supplied stride at `(x, y)`, proceeding for its full
-        /// length.
-        ///
-        /// Out-of-range start co-ordinates cause a no-op.
-        ///
-        /// It's expected that src will fit; overruns are safety-checked
-        /// undefined behavior.
-        pub fn putStride(self: *PackedImageSurface(T), x: i32, y: i32, src: pixel.Stride) void {
-            if (x < 0 or y < 0 or x >= self.width or y >= self.height) return;
-            self.getStride(x, y, src.pxLen()).copy(src);
         }
 
         /// Replaces the surface with the supplied pixel.
@@ -1600,5 +1564,29 @@ test "PackedImageSurface.downsample, edge cases" {
         try testing.expectEqual(4, sfc.width);
         try testing.expectEqual(3, sfc.height);
         try testing.expectEqual(pixel.Pixel{ .alpha1 = .{ .a = 1 } }, sfc.getPixel(0, 0));
+    }
+}
+
+test "getStride, OOB" {
+    const alloc = testing.allocator;
+    inline for (@typeInfo(SurfaceType).@"enum".fields) |sfc_type| {
+        var sfc = try Surface.init(@enumFromInt(sfc_type.value), alloc, 10, 10);
+        defer sfc.deinit(alloc);
+        inline for (.{ -10, 5, 20 }) |x| {
+            inline for (.{ -10, 5, 20 }) |y| {
+                const got = sfc.getStride(x, y, 2);
+                if (x < 0 or y < 0 or x >= 10 or y >= 10) {
+                    testing.expectEqual(0, got.pxLen()) catch |err| {
+                        debug.print("bad len on x={d}, y={d}, surface type: {s}\n", .{ x, y, sfc_type.name });
+                        return err;
+                    };
+                } else {
+                    testing.expectEqual(2, got.pxLen()) catch |err| {
+                        debug.print("bad len on x={d}, y={d}, surface type: {s}\n", .{ x, y, sfc_type.name });
+                        return err;
+                    };
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This removes `copyStride` from the pixel package, in addition to other related unused functionality. This was alluded to be being planned in test comments in 158a006aec055dc11b5c271cc7e0a10917762808, meaning I was planning on doing it pretty much right after. ;)

Also adds a test for OOB index `getStride` (made coverage for surfaces more green).