### PR TITLE
aligncast for compiling in wasm32

### DIFF
--- a/src/internal/Polygon.zig
+++ b/src/internal/Polygon.zig
@@ -256,7 +256,7 @@ pub const Contour = struct {
         node: std.DoublyLinkedList.Node = .{},
 
         pub fn fromNode(n: *std.DoublyLinkedList.Node) *Corner {
-            return @fieldParentPtr("node", n);
+            return @alignCast(@fieldParentPtr("node", n));
         }
     };
 


### PR DESCRIPTION
Found when updating dvui to zig 0.15.1  (dvui -> zig-lib-svg2tvg -> z2d)  Thank you!