### PR TITLE
Polygon - introduce the working edge set

### DIFF
--- a/src/internal/fill_plotter.zig
+++ b/src/internal/fill_plotter.zig
@@ -136,18 +136,16 @@ test "degenerate line_to" {
     try testing.expectEqual(2, result.edges.items.len);
     try testing.expectEqualSlices(Polygon.Edge, &.{
         .{
-            .top = 0.0,
-            .bottom = 10.0,
+            .y0 = 0.0,
+            .y1 = 10.0,
             .x_start = 5.0,
             .x_inc = 0.5,
-            .dir = -1,
         },
         .{
-            .top = 0.0,
-            .bottom = 10.0,
+            .y0 = 10.0,
+            .y1 = 0.0,
             .x_start = 5.0,
             .x_inc = -0.5,
-            .dir = 1,
         },
     }, result.edges.items);
 }
@@ -168,11 +166,10 @@ test "degenerate close" {
         try testing.expectEqual(1, result.edges.items.len);
         try testing.expectEqualSlices(Polygon.Edge, &.{
             .{
-                .top = 0.0,
-                .bottom = 10.0,
+                .y0 = 0.0,
+                .y1 = 10.0,
                 .x_start = 5.0,
                 .x_inc = 0.5,
-                .dir = -1,
             },
         }, result.edges.items);
     }
@@ -196,18 +193,16 @@ test "degenerate close" {
         try testing.expectEqual(2, result.edges.items.len);
         try testing.expectEqualSlices(Polygon.Edge, &.{
             .{
-                .top = 0.0,
-                .bottom = 10.0,
+                .y0 = 0.0,
+                .y1 = 10.0,
                 .x_start = 5.0,
                 .x_inc = 0.5,
-                .dir = -1,
             },
             .{
-                .top = 0.0,
-                .bottom = 10.0,
+                .y0 = 10.0,
+                .y1 = 0.0,
                 .x_start = 5.0,
                 .x_inc = -0.5,
-                .dir = 1,
             },
         }, result.edges.items);
     }


### PR DESCRIPTION
This introduces the concept of a _working edge set_ to the rasterization process, which aims to reduce the amount that the full set of tessellated edges are iterated over for a particular scanline.

This will benefit drawing operations that have some combination of a large amount of edges where each edge does not cover the entirety of the y-axis of the draw area. Naturally, anti-aliased operations benefit more due to the super-sampled co-ordinate space.

In brief, the model is as follows:

* A global working edge set stores both pointers to active edges and an equal amount of memory for calculated x-coordinates, and also pre-calculated directions (see below).
* Edge top and bottom co-ordinates are collected as a series of breakpoints.
* `xEdgesForY` now only runs on these breakpoints, updating the set of active edges.
* Edge x-coordinates are still calculated, sorted, and filtered each scanline. This section has been tightened a bit to just use symmetrical memory versus a `MultiArrayList` (allows us to manually slice and gives us better control over the memory).

Note that in an effort to better align the global edge set, some changes have also been made to what an edge looks like. Direction has been removed from edge, and that, along with top and bottom, are now conditionally returned through helpers (`y0` and `y1` are stored now with no
regard to direction). This allows the full edge top/bottom/start/inc pair to be stored in a proper power-of-two aligned fashion (32 bytes instead of 40). Testing has actually shown a slight advantage to this approach in terms of cycle count and possibly much better utilization of
the branch predictor (much lower branch miss count). We still store a cached direction in the active edge set because, funny enough, removing this and relying fully on the helper actually lowers performance again (even though we get even better branch prediction performance, funny
enough).