### PR TITLE
painter: fast-path to memset for fully opaque operations

### DIFF
--- a/src/compositor.zig
+++ b/src/compositor.zig
@@ -193,6 +193,17 @@ pub const Operator = enum {
             else => true,
         };
     }
+
+    /// Returns true if the operator can be fast-pathed on the source if the
+    /// source is opaque by writing the source pixel directly to the surface.
+    pub fn canFastPathSrc(op: Operator) bool {
+        return switch (op) {
+            .src,
+            .src_over,
+            => true,
+            else => false,
+        };
+    }
 };
 
 /// List of the supported compositor precision types.

--- a/src/painter.zig
+++ b/src/painter.zig
@@ -409,23 +409,29 @@ fn paintDirect(
             }
 
             if (fill_len > 0) {
-                const dst_stride = surface.getStride(start_x, y, @max(0, fill_len));
-                compositor.StrideCompositor.run(dst_stride, &.{.{
-                    .operator = operator,
-                    .src = switch (pattern.*) {
-                        .opaque_pattern => .{ .pixel = pattern.opaque_pattern.pixel },
-                        .gradient => |g| .{ .gradient = .{
-                            .underlying = g,
-                            .x = start_x,
-                            .y = y,
-                        } },
-                        .dither => .{ .dither = .{
-                            .underlying = pattern.dither,
-                            .x = start_x,
-                            .y = y,
-                        } },
-                    },
-                }}, .{ .precision = _precision });
+                if (pattern.* == .opaque_pattern and operator.canFastPathSrc() and
+                    pattern.opaque_pattern.pixel.isOpaque())
+                {
+                    surface.paintStride(start_x, y, @max(0, fill_len), pattern.opaque_pattern.pixel);
+                } else {
+                    const dst_stride = surface.getStride(start_x, y, @max(0, fill_len));
+                    compositor.StrideCompositor.run(dst_stride, &.{.{
+                        .operator = operator,
+                        .src = switch (pattern.*) {
+                            .opaque_pattern => .{ .pixel = pattern.opaque_pattern.pixel },
+                            .gradient => |g| .{ .gradient = .{
+                                .underlying = g,
+                                .x = start_x,
+                                .y = y,
+                            } },
+                            .dither => .{ .dither = .{
+                                .underlying = pattern.dither,
+                                .x = start_x,
+                                .y = y,
+                            } },
+                        },
+                    }}, .{ .precision = _precision });
+                }
             }
 
             if (!bounded and end_clear_len > 0) {
@@ -824,23 +830,29 @@ fn paintMultiSample(
                 0 => {}, // Skip zero entries
                 coverage_full => {
                     // Fully opaque span, so we can just composite directly (no alpha).
-                    const dst_stride = surface.getStride(x, y, coverage_len);
-                    compositor.StrideCompositor.run(dst_stride, &.{.{
-                        .operator = operator,
-                        .src = switch (pattern.*) {
-                            .opaque_pattern => .{ .pixel = pattern.opaque_pattern.pixel },
-                            .gradient => |g| .{ .gradient = .{
-                                .underlying = g,
-                                .x = x,
-                                .y = y,
-                            } },
-                            .dither => .{ .dither = .{
-                                .underlying = pattern.dither,
-                                .x = x,
-                                .y = y,
-                            } },
-                        },
-                    }}, .{ .precision = _precision });
+                    if (pattern.* == .opaque_pattern and operator.canFastPathSrc() and
+                        pattern.opaque_pattern.pixel.isOpaque())
+                    {
+                        surface.paintStride(x, y, coverage_len, pattern.opaque_pattern.pixel);
+                    } else {
+                        const dst_stride = surface.getStride(x, y, coverage_len);
+                        compositor.StrideCompositor.run(dst_stride, &.{.{
+                            .operator = operator,
+                            .src = switch (pattern.*) {
+                                .opaque_pattern => .{ .pixel = pattern.opaque_pattern.pixel },
+                                .gradient => |g| .{ .gradient = .{
+                                    .underlying = g,
+                                    .x = x,
+                                    .y = y,
+                                } },
+                                .dither => .{ .dither = .{
+                                    .underlying = pattern.dither,
+                                    .x = x,
+                                    .y = y,
+                                } },
+                            },
+                        }}, .{ .precision = _precision });
+                    }
                 },
                 else => {
                     // Span with some degree of (> 0, < max) opacity, so we

--- a/src/pixel.zig
+++ b/src/pixel.zig
@@ -119,6 +119,26 @@ pub const Pixel = union(Format) {
     pub fn fromColor(color: Color.InitArgs) Pixel {
         return colorpkg.LinearRGB.fromColor(Color.init(color)).encodeRGBA().asPixel();
     }
+
+    /// Convenience method that returns true if the pixel is full-opacity.
+    ///
+    /// Note that:
+    ///
+    ///  * Any pixel type lacking an alpha channel (e.g., `RGB`) is always
+    ///    considered opaque.
+    ///  * Alpha types (e.g., `Alpha8` or the sub-8-bit versions) follow the
+    ///    same opacity rules as RGBA types (full opacity is max alpha channel
+    ///    value). Keep this in mind when using alpha-only pixel types to
+    ///    represent grayscale.
+    pub fn isOpaque(self: Pixel) bool {
+        return switch (self) {
+            inline .xrgb, .rgb => true,
+            inline .argb, .rgba, .alpha8 => |px| px.a == 255,
+            .alpha4 => |px| px.a == 15,
+            .alpha2 => |px| px.a == 3,
+            .alpha1 => |px| px.a == 1,
+        };
+    }
 };
 
 /// Describes a 32-bit little-endian xRGB format (can also be thought of as


### PR DESCRIPTION
This sets up the painter for an optimization that, frankly, should have been made a long time ago - fast-tracking opaque operations in the event that they can be.

Now, when drawing with MSAA (the default currently) or no anti-aliasing at all, when the source is fully opaque and the operation is effectively a source-exclusive one, the compositor will fast-path to just doing a memset on the surface via `paintStride`.

This results in significant performance gains in both the MSAA and no anti-aliasing scenarios for these trivial cases (painting with a single solid color).

Not affected by this change: using gradient sources or non-opaque sources, as these need to go through the compositor pipeline still to do the appropriate operations. SSAA is also not affected; while the mask is built using `paintStride`, the nature of the operation in its entirety still demands everything go through the compositor pipeline after the mask is built and downsampled.

Note that this change is in its early stages and will be built upon - more operators will be identified, and other scenarios where we can fast-path the source for non-opaque sources will be identified as well (e.g., `.src` can be for non-opaque because the source completely replaces the destination).