### PR TITLE
sparse_coverage: make splitInner loop break conditions consistent

### DIFF
--- a/src/internal/sparse_coverage.zig
+++ b/src/internal/sparse_coverage.zig
@@ -219,13 +219,11 @@ pub const SparseCoverageBuffer = struct {
                 self.put(idx, current_value, rem);
                 self.put(idx + rem, current_value, current_len - rem);
                 break;
+            } else if (rem == current_len) {
+                break;
             }
 
             rem -= current_len;
-            if (rem == 0) {
-                return;
-            }
-
             idx += current_len;
         }
     }


### PR DESCRIPTION
There was some inconsistencies here that were a relic of adapting the code from tiny-skia. This is just a small cleanup to put the break conditions into the same area (so now break condition is effectively `<= current_len`) and ensure that both conditions break the loop (rather than one return).