### PR TITLE
raster: refactor SparseCoverageBuffer

### DIFF
--- a/src/internal/raster/sparse_coverage.zig
+++ b/src/internal/raster/sparse_coverage.zig
@@ -16,22 +16,29 @@ const runCases = @import("../util.zig").runCases;
 const TestingError = @import("../util.zig").TestingError;
 
 /// A structure for representing run-length-encoded coverage for a single
-/// scanline. This facilities MSAA by taking supersampled co-ordinates and
-/// recording the coverage as the number of pixels set in a particular unit of
-/// scale (currently hardcoded to 4x). In memory, this is stored as two sparse
-/// buffers; one for the coverage as a []u8, and the other for lengths whose
-/// underlying type is dependent on the total capacity; most notably, this
-/// means that the coverage and length storage combined will only use a maximum
-/// of 510 bytes of memory for scanlines of less than 256 pixels.
+/// scanline. This facilities anti-aliasing by allowing the recording of
+/// coverage spans over single or multiple calls. In memory, this is stored
+/// as two sparse buffers; one for the coverage as a []u8, and the other for
+/// lengths whose underlying type is dependent on the total capacity; most
+/// notably, this means that the coverage and length storage combined will only
+/// use a maximum of 510 bytes of memory for scanlines of less than 256 pixels.
 ///
-/// To use the buffer when performing MSAA composition, record spans in groups
-/// of `scale` in super-sampled space (appropriately offset to fully take
-/// advantage of the above space optimization for span lengths), then write the
-/// values out by x-coordinates in device space starting at x=0, and
-/// incrementing on the length returned by `get`. As the `value` is the total
-/// coverage in pixels, make sure to take the set count and calculate the
-/// actual opacity as a multiple of `256 / (scale * scale)`, subtracting 1 and
-/// clamping afterwards to give the 0-255 range.
+/// Calculating actual coverage to add or set is an exercise local to the
+/// specific rasterizer, i.e., no calculations for scale, etc, are not done
+/// here.
+///
+/// An example of how coverage is recorded is discussed here, in the MSAA
+/// context (see rasterizer/multiplesample.zig for more details):
+///
+/// To use the buffer when performing MSAA composition, spans are recorded in
+/// groups of `scale` in super-sampled space (appropriately offset to fully
+/// take advantage of the above space optimization for span lengths). After
+/// recording the full set of sub-scanlines, values are written out by
+/// x-coordinates in device space starting at x=0, and incrementing on the
+/// length returned by `get`. As the `value` is the total coverage in pixels,
+/// make sure to take the set count and calculate the actual opacity as a
+/// multiple of `256 / (scale * scale)`, subtracting 1 and clamping afterwards
+/// to give the 0-255 range.
 ///
 /// Consider also fast-pathing when the coverage value is either 0 or the
 /// maximum (i.e., `scale * scale`).
@@ -41,8 +48,6 @@ const TestingError = @import("../util.zig").TestingError;
 /// values, ensuring pixels are not counted more than once, are provided by the
 /// caller.
 pub const SparseCoverageBuffer = struct {
-    pub const scale = 4;
-
     values: []u8,
     lengths: LengthStorage,
     len: u32,
@@ -84,72 +89,41 @@ pub const SparseCoverageBuffer = struct {
         }
     }
 
-    /// Adds a span at `x`, running for `len`. Both `x` and `len` must be
-    /// supplied in super-sampled co-ordinates. Assumes that co-ordinates have
-    /// already been appropriately clamped correctly to be non-negative and
-    /// cropped for length (e.g., x=-5, len=10 should be clamped and clipped to
-    /// x=0, len=5).
-    ///
-    /// Will extend the coverage set if necessary by adding space and/or
-    /// splitting spans, before adding the coverage for the span.
-    pub fn addSpan(self: *SparseCoverageBuffer, x: u32, len: u32) void {
-        if (x + len > self.capacity * scale) {
-            @panic("attempt to add span beyond capacity. this is a bug, please report it");
-        }
-
-        if (len == 0) return;
-
-        // Start co-ordinates and coverage
-        const start_x: u32 = x / scale;
-        const start_offset: u32 = x - start_x * scale; // Bit offset of start-x
-
-        if (start_offset == 0 and len >= scale) {
-            // Start coverage is full, so optimize this by writing out full
-            // coverage for the maximum length that we can, then write out the end
-            // (if needed).
-            const front_len: u32 = len / scale; // Opaque span len
-            self.extendAndSetOpaque(start_x, front_len);
-            const end_coverage: u8 = @min(scale, len - front_len * scale);
-            if (end_coverage > 0) {
-                // Only add end coverage if we need it
-                self.extendAndSetSingle(start_x + front_len, end_coverage);
-            }
-        } else {
-            // Write out front
-            const start_coverage_raw: u8 = @min(scale, @min(len, scale - start_offset));
-            self.extendAndSetSingle(start_x, start_coverage_raw);
-
-            // Write out middle (if needed)
-            const after_start_raw = len - start_coverage_raw;
-            const mid_len: u32 = after_start_raw / scale;
-            if (mid_len > 0) {
-                self.extendAndSetOpaque(start_x + 1, mid_len);
-            }
-
-            // Write out end (if needed)
-            const end_coverage_raw = @min(scale, after_start_raw - mid_len * scale);
-            if (end_coverage_raw > 0) {
-                self.extendAndSetSingle(start_x + 1 + mid_len, end_coverage_raw);
-            }
-        }
-    }
-
-    fn extendAndSetOpaque(self: *SparseCoverageBuffer, x: u32, len: u32) void {
+    pub fn addSpan(self: *SparseCoverageBuffer, x: u32, value: u8, len: u32) void {
         self.extend(x, len);
         var x_cur: u32 = x;
         const x_end: u32 = x + len;
         while (x_cur < x_end) {
             var coverage_value, const coverage_len = self.get(x_cur);
-            coverage_value += scale;
+            coverage_value += value;
             self.putValue(x_cur, coverage_value);
             x_cur += coverage_len;
         }
     }
 
-    fn extendAndSetSingle(self: *SparseCoverageBuffer, x: u32, value: u8) void {
+    pub fn addSingle(self: *SparseCoverageBuffer, x: u32, value: u8) void {
         self.extend(x, 1);
         var coverage_value, _ = self.get(x);
         coverage_value += value;
+        self.putValue(x, coverage_value);
+    }
+
+    pub fn setSpan(self: *SparseCoverageBuffer, x: u32, value: u8, len: u32) void {
+        self.extend(x, len);
+        var x_cur: u32 = x;
+        const x_end: u32 = x + len;
+        while (x_cur < x_end) {
+            var coverage_value, const coverage_len = self.get(x_cur);
+            coverage_value = value;
+            self.putValue(x_cur, coverage_value);
+            x_cur += coverage_len;
+        }
+    }
+
+    pub fn subSingle(self: *SparseCoverageBuffer, x: u32, value: u8) void {
+        self.extend(x, 1);
+        var coverage_value, _ = self.get(x);
+        coverage_value -= value;
         self.putValue(x, coverage_value);
     }
 
@@ -355,155 +329,6 @@ test "extend, zero len" {
     coverage.extend(0, 0);
     _, const got_len = coverage.get(0);
     try testing.expectEqual(0, got_len);
-}
-
-test "addSpan" {
-    // Simple triangle in the midpoint/cross-section, assuming a scanline
-    // edge of (50, 0) to (149, 0), so len = 100. We start out and expand
-    // in.
-    const alloc = testing.allocator;
-    var coverage: SparseCoverageBuffer = try .init(alloc, 1024);
-    defer coverage.deinit(alloc);
-    coverage.addSpan(200, 400);
-    try testing.expectEqual(.{ 4, 100 }, coverage.get(50));
-
-    coverage.addSpan(201, 398);
-    try testing.expectEqual(.{ 7, 1 }, coverage.get(50));
-    try testing.expectEqual(.{ 8, 98 }, coverage.get(51));
-    try testing.expectEqual(.{ 7, 1 }, coverage.get(149));
-
-    coverage.addSpan(202, 396);
-    try testing.expectEqual(.{ 9, 1 }, coverage.get(50));
-    try testing.expectEqual(.{ 12, 98 }, coverage.get(51));
-    try testing.expectEqual(.{ 9, 1 }, coverage.get(149));
-
-    coverage.addSpan(203, 394);
-    try testing.expectEqual(.{ 10, 1 }, coverage.get(50));
-    try testing.expectEqual(.{ 16, 98 }, coverage.get(51));
-    try testing.expectEqual(.{ 10, 1 }, coverage.get(149));
-
-    var x: u32 = 0;
-    var tracked_span_len: usize = 0;
-    while (x < coverage.len) {
-        _, const x_inc = coverage.get(x);
-        x += x_inc;
-        tracked_span_len += 1;
-    }
-    try testing.expectEqual(4, tracked_span_len);
-}
-
-test "addSpan, capacity tests/checks" {
-    // As above, just deliberately checking capacities (most of the other tests
-    // will just be initializing u8 length buffers).
-    //
-    // Note that these tests use a lot of memory, approx 655K peak!
-    // I don't really think this is an issue though, since our acceptance test
-    // suite (in spec/) uses probably about this much in general (or much more)
-    // in our supersample tests. Consider our small capacity case: 2 []u8's
-    // (one for values, one for lengths), with a maximum supported scanline
-    // length of 255, yields only 510 bytes needed for the entire buffer;
-    // compare this to a supersample case of 255x255: 260100 bytes (255x255x4)!
-    // This is actually a great demonstration of the savings that we're getting
-    // using the sparse buffer, even with the small amount of the space that's
-    // actually used in it.
-    //
-    // Regardless, if it's an issue, you can get this test using a modest
-    // amount of RAM by removing the larger tests (the ones past the u8
-    // boundary, particularly).
-
-    const name = "addSpan, capacity tests/checks";
-    const cases = [_]struct {
-        name: []const u8,
-        capacity: u32,
-        expected_T: []const u8,
-    }{
-        .{
-            .name = "u8 (max case)",
-            .capacity = 255,
-            .expected_T = "u8",
-        },
-        .{
-            .name = "u16 (u8 boundary)",
-            .capacity = 256,
-            .expected_T = "u16",
-        },
-        .{
-            .name = "u16 (max case)",
-            .capacity = 65535,
-            .expected_T = "u16",
-        },
-        .{
-            .name = "u32 (u16 boundary)",
-            .capacity = 65536,
-            .expected_T = "u32",
-        },
-        .{
-            .name = "u32",
-            .capacity = 131072,
-            .expected_T = "u32",
-        },
-    };
-    const TestFn = struct {
-        fn f(tc: anytype) TestingError!void {
-            const alloc = testing.allocator;
-            var coverage: SparseCoverageBuffer = try .init(alloc, tc.capacity);
-            defer coverage.deinit(alloc);
-            try testing.expectEqualSlices(u8, tc.expected_T, @tagName(coverage.lengths));
-
-            var got_val: u8 = undefined;
-            var got_len: u32 = undefined;
-
-            const cap_supersample = tc.capacity * 4;
-
-            coverage.addSpan(0, cap_supersample);
-            got_val, got_len = coverage.get(0);
-            try testing.expectEqual(4, got_val);
-            try testing.expectEqual(tc.capacity, got_len);
-
-            coverage.addSpan(1, cap_supersample - 2);
-            got_val, got_len = coverage.get(0);
-            try testing.expectEqual(7, got_val);
-            try testing.expectEqual(1, got_len);
-            got_val, got_len = coverage.get(1);
-            try testing.expectEqual(8, got_val);
-            try testing.expectEqual(tc.capacity - 2, got_len);
-            got_val, got_len = coverage.get(tc.capacity - 1);
-            try testing.expectEqual(7, got_val);
-            try testing.expectEqual(1, got_len);
-
-            coverage.addSpan(2, cap_supersample - 4);
-            got_val, got_len = coverage.get(0);
-            try testing.expectEqual(9, got_val);
-            try testing.expectEqual(1, got_len);
-            got_val, got_len = coverage.get(1);
-            try testing.expectEqual(12, got_val);
-            try testing.expectEqual(tc.capacity - 2, got_len);
-            got_val, got_len = coverage.get(tc.capacity - 1);
-            try testing.expectEqual(9, got_val);
-            try testing.expectEqual(1, got_len);
-
-            coverage.addSpan(3, cap_supersample - 6);
-            got_val, got_len = coverage.get(0);
-            try testing.expectEqual(10, got_val);
-            try testing.expectEqual(1, got_len);
-            got_val, got_len = coverage.get(1);
-            try testing.expectEqual(16, got_val);
-            try testing.expectEqual(tc.capacity - 2, got_len);
-            got_val, got_len = coverage.get(tc.capacity - 1);
-            try testing.expectEqual(10, got_val);
-            try testing.expectEqual(1, got_len);
-
-            var x: u32 = 0;
-            var tracked_span_len: usize = 0;
-            while (x < coverage.len) {
-                _, const x_inc = coverage.get(x);
-                x += x_inc;
-                tracked_span_len += 1;
-            }
-            try testing.expectEqual(3, tracked_span_len);
-        }
-    };
-    try runCases(name, cases, TestFn.f);
 }
 
 // Uncomment this to test (expect assertion failure or intCast safety check)

--- a/src/painter.zig
+++ b/src/painter.zig
@@ -75,7 +75,7 @@ pub fn fill(
     const scale: f64 = switch (aa_mode) {
         .none => 1,
         .supersample_4x => supersample_scale,
-        .default, .multisample_4x => SparseCoverageBuffer.scale,
+        .default, .multisample_4x => multisample_rasterizer.scale,
     };
 
     var polygons = try fill_plotter.plot(
@@ -202,7 +202,7 @@ pub fn stroke(
     const scale: f64 = switch (aa_mode) {
         .none => 1,
         .supersample_4x => supersample_scale,
-        .default, .multisample_4x => SparseCoverageBuffer.scale,
+        .default, .multisample_4x => multisample_rasterizer.scale,
     };
 
     // NOTE: for now, we set a minimum thickness for the following options:


### PR DESCRIPTION
This refactors `SparseCoverageBuffer` to make it more flexible for other types of anti-aliasing rather than just the 4x MSAA:

* The previous `addSpan` has been moved to `multisample.zig`, communicating the intent that this function specific to the MSAA method of rasterization, namely scaling with the appropriate factor is a product of MSAA and not necessarily other methods.

* Pursuant to the above, scaling is no longer a concern of `SparseCoverageBuffer`. All functions assume a device-local co-ordinate space.

* Moved `extendAndSetOpaque` to `addSpan`, and `extendAndSetSingle` to `addSingle`. Added `setSpan` (which will hard set the coverage value), and `subSingle` (subtracts a coverage value). All of these methods are also pub.